### PR TITLE
Don't turn TypeError into SessionExpired

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -466,6 +466,8 @@ class KazooClient(object):
                 async_result.set_exception(
                     self.zookeeper.InvalidStateException(
                         "invalid handle state"))
+            elif isinstance(exc, TypeError):
+                async_result.set_exception(exc)
             else:
                 async_result.set_exception(
                     self.zookeeper.SessionExpiredException("session expired"))


### PR DESCRIPTION
If a programmer screws up and sends bad data to zookeeper, especially as
part of set_config, be sure that that relatively simple TypeError is
allowed to propagate to the caller. The old behavior was that a
misleading SessionExpired error was sent to the caller.

I understand that _safe_call is called by a whole host of other routines and I may have oversimplified this patch. I'm hopeful that this patch or something like it that keeps the original TypeError will be acceptable.
