### PR TITLE
Allow handler gevent workers and threads to exit gracefully on KazooClient.stop() or exit.

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -586,6 +586,7 @@ class KazooClient(object):
 
     def _safe_close(self):
         if self._handle is not None:
+            self.handler.stop()
             zh, self._handle = self._handle, None
             try:
                 self.zookeeper.close(zh)
@@ -611,6 +612,8 @@ class KazooClient(object):
 
         # We've been asked to connect, clear the stop
         self._stopped.clear()
+
+        self.handler.start()
 
         cb = self._wrap_session_callback(self._session_callback)
         if self._provided_client_id:

--- a/kazoo/interfaces.py
+++ b/kazoo/interfaces.py
@@ -32,6 +32,12 @@ class IHandler(Interface):
         """Appropriate sleep function that can be called with a single
         argument and sleep.""")
 
+    def start():
+        """Start the handler."""
+
+    def stop():
+        """Stop the handler."""
+
     def event_object():
         """Return an appropriate object that implements Python's
         threading.Event API"""


### PR DESCRIPTION
- Added start() and stop() functions to the IHandler interface.
  - Added calls to IHandler.start()/stop() to KazooClient._safe_close()
    and KazooClient.async_connect()
  - Added atexit to register calling the stop functions for running
    handlers, in case KazooClient.stop() isn't called.
