### PR TITLE
Made gevent's timeout exception behave like python's 

### DIFF
--- a/kazoo/handlers/gevent.py
+++ b/kazoo/handlers/gevent.py
@@ -101,8 +101,11 @@ class SequentialGeventHandler(object):
 
     """
     name = "sequential_gevent_handler"
-    timeout_exception = gevent.event.Timeout
     sleep_func = staticmethod(gevent.sleep)
+
+    class timeout_exception(gevent.event.Timeout):
+        def __init__(self, msg):
+            gevent.event.Timeout.__init__(self, exception=msg)
 
     def __init__(self, hub=None):
         """Create a :class:`SequentialGeventHandler` instance"""


### PR DESCRIPTION
gevent.event.Timeout's constructor defies standards by looking like this:

  **init**(self, seconds=None, exception=None, ref=True, priority=-1)

In order to pass a message in we must use the exception karg (or specify seconds).

This addresses github issue #17
