### PR TITLE
Overhaul debian packaging.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,17 +1,5 @@
-kazoo (0.8) unstable; urgency=low
+kazoo (0+git20130102) unstable; urgency=low
 
-  * New upstream release.
+  * Initial package.
 
- -- Hanno Schlichting <hschlichting@mozilla.com>  Fir, 26 Oct 2012 12:05:00 +0200
-
-kazoo (0.7) unstable; urgency=low
-
-  * New upstream release.
-
- -- Hanno Schlichting <hschlichting@mozilla.com>  Mon, 15 Oct 2012 12:05:00 +0200
-
-kazoo (0.6) unstable; urgency=low
-
-  * Packaged for debian.
-
- -- Neil Williams <neil@reddit.com>  Tue, 07 Aug 2012 23:22:19 -0700
+ -- Neil Williams <neil@spladug.net>  Fri, 02 Jan 2013 23:20:03 -0800

--- a/debian/clean
+++ b/debian/clean
@@ -1,0 +1,1 @@
+kazoo.egg-info/*

--- a/debian/control
+++ b/debian/control
@@ -1,19 +1,19 @@
 Source: kazoo
 Section: python
 Priority: optional
-Maintainer: Kazoo Team <user@zookeeper.apache.org>
+Maintainer: Neil Williams <neil@spladug.net>
 Build-Depends: python-setuptools (>= 0.6b3),
                python-all (>= 2.6.6-3),
-               debhelper (>= 8.0.0)
+               debhelper (>= 8.0.0),
+               python-repoze.sphinx.autointerface,
+               python-sphinx (>= 1.0.7+dfsg) | python3-sphinx,
 Standards-Version: 3.9.3
 Homepage: https://kazoo.readthedocs.org
-Vcs-Git: git://github.com/python-zk/kazoo.git
-Vcs-Browser: https://github.com/python-zk/kazoo
 
 Package: python-kazoo
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}
-Description: higher level API to Apache Zookeeper for Python clients.
+Description: higher level API to Apache Zookeeper for Python clients
  Kazoo features:
  .
   * Support for gevent 0.13 and gevent 1.0b
@@ -31,8 +31,8 @@ Description: higher level API to Apache Zookeeper for Python clients.
 Package: python-kazoo-doc
 Architecture: all
 Section: doc
-Depends: ${misc:Depends}, ${python:Depends}
-Description: higher level API to Apache Zookeeper for Python clients. - API documentation
+Depends: ${misc:Depends}, ${sphinxdoc:Depends}
+Description: API to Apache Zookeeper for Python clients. - API documentation
  Kazoo features:
  .
   * Support for gevent 0.13 and gevent 1.0b

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,8 +1,13 @@
-Format: http://dep.debian.net/deps/dep5
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: kazoo
 Source: https://github.com/python-zk/kazoo
 
 Files: *
 Copyright: 2012 Kazoo Team
+License: Apache-2.0
+ See /usr/share/common-licenses/Apache-2.0
+
+Files: debian/*
+Copyright: 2012 Neil Williams <neil@spladug.net>
 License: Apache-2.0
  See /usr/share/common-licenses/Apache-2.0

--- a/debian/docs
+++ b/debian/docs
@@ -1,2 +1,1 @@
 README.rst
-CHANGES.rst

--- a/debian/patches/no-tag-build.patch
+++ b/debian/patches/no-tag-build.patch
@@ -1,0 +1,15 @@
+Description: Unset build_tag so the installed module isn't "dev" suffixed.
+Author: Neil Williams <neil@spladug.net>
+Forwarded: not-needed
+Last-Update: 2012-12-24
+Index: kazoo/setup.cfg
+===================================================================
+--- kazoo.orig/setup.cfg	2012-12-21 19:25:50.649997478 -0800
++++ kazoo/setup.cfg	2012-12-23 22:43:45.557703554 -0800
+@@ -1,5 +1,5 @@
+ [egg_info]
+-tag_build = dev
++tag_build =
+ 
+ [nosetests]
+ where=kazoo

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+no-tag-build.patch

--- a/debian/python-kazoo-doc.doc-base
+++ b/debian/python-kazoo-doc.doc-base
@@ -1,0 +1,10 @@
+Document: python-kazoo-doc
+Title: Python Kazoo Documentation
+Author: Kazoo Team
+Section: Programming/Python
+
+Format: HTML
+Index: /usr/share/doc/python-kazoo-doc/html/index.html
+Files: /usr/share/doc/python-kazoo-doc/html/*.html
+       /usr/share/doc/python-kazoo-doc/html/api/*.html
+       /usr/share/doc/python-kazoo-doc/html/api/*/*.html

--- a/debian/python-kazoo-doc.docs
+++ b/debian/python-kazoo-doc.docs
@@ -1,0 +1,1 @@
+build/html

--- a/debian/python-kazoo-doc.install
+++ b/debian/python-kazoo-doc.install
@@ -1,1 +1,0 @@
-docs /usr/share/doc/python-kazoo-doc/

--- a/debian/python-kazoo.install
+++ b/debian/python-kazoo.install
@@ -1,2 +1,1 @@
-debian/tmp/usr/lib/python*/dist-packages/kazoo
-debian/tmp/usr/lib/python*/dist-packages/kazoo-*.egg-info
+usr/lib/python2*

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,18 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --with python2 --buildsystem=python_distutils
+	dh $@ --with python2,sphinxdoc --buildsystem=python_distutils
+
+.PHONY: override_dh_installchangelogs
+override_dh_installchangelogs:
+	dh_installchangelogs CHANGES.rst
+
+.PHONY: override_dh_auto_build
+override_dh_auto_build:
+	sphinx-build -b html docs build/html
+	dh_auto_build
+
+.PHONY: override_dh_clean
+override_dh_clean:
+	rm -rf build
+	dh_clean

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)

--- a/debian/watch
+++ b/debian/watch
@@ -1,0 +1,2 @@
+version=3
+https://github.com/python-zk/kazoo/tags .*/(\d[\d\.]+)\.tar\.gz


### PR DESCRIPTION
Kazoo is [going to be in Debian proper now](http://ftp-master.debian.org/new/kazoo_0.8-1.html). These are the changes made
during the review process.

The changelog is now a dummy one and doesn't need to be updated with new releases.
