### PR TITLE
Set X-Python-Version to >= 2.6

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Build-Depends: python-setuptools (>= 0.6b3),
                python-sphinx (>= 1.0.7+dfsg) | python3-sphinx,
 Standards-Version: 3.9.3
 Homepage: https://kazoo.readthedocs.org
+X-Python-Version: >= 2.6
 
 Package: python-kazoo
 Architecture: all


### PR DESCRIPTION
Squeeze builds fail without this flag as the python-all will force
build on 2.5 too.
