### PR TITLE
Compatibility with zope.interface < 3.6.0.

### DIFF
--- a/kazoo/handlers/gevent.py
+++ b/kazoo/handlers/gevent.py
@@ -14,7 +14,7 @@ import gevent.select
 from gevent.queue import Empty
 from gevent.queue import Queue
 from gevent import socket
-from zope.interface import implementer
+from zope.interface import implements, classImplements
 
 from kazoo.handlers.utils import create_tcp_socket
 from kazoo.interfaces import IAsyncResult
@@ -26,10 +26,10 @@ log = logging.getLogger(__name__)
 
 _STOP = object()
 
-AsyncResult = implementer(IAsyncResult)(gevent.event.AsyncResult)
+AsyncResult = gevent.event.AsyncResult
+classImplements(AsyncResult, IAsyncResult)
 
 
-@implementer(IHandler)
 class SequentialGeventHandler(object):
     """Gevent handler for sequentially executing callbacks.
 
@@ -50,6 +50,8 @@ class SequentialGeventHandler(object):
     proceed.
 
     """
+    implements(IHandler)
+
     name = "sequential_gevent_handler"
     sleep_func = staticmethod(gevent.sleep)
 

--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -24,7 +24,7 @@ try:
 except ImportError:  # pragma: nocover
     import queue as Queue
 
-from zope.interface import implementer
+from zope.interface import implements
 
 from kazoo.handlers.utils import create_tcp_socket
 from kazoo.interfaces import IAsyncResult
@@ -41,9 +41,11 @@ class TimeoutError(Exception):
     pass
 
 
-@implementer(IAsyncResult)
 class AsyncResult(object):
     """A one-time event that stores a value or an exception"""
+
+    implements(IAsyncResult)
+
     def __init__(self, handler):
         self._handler = handler
         self.value = None
@@ -148,7 +150,6 @@ class AsyncResult(object):
                 self._callbacks.remove(callback)
 
 
-@implementer(IHandler)
 class SequentialThreadingHandler(object):
     """Threading handler for sequentially executing callbacks.
 
@@ -177,6 +178,9 @@ class SequentialThreadingHandler(object):
         returns.
 
     """
+
+    implements(IHandler)
+
     name = "sequential_threading_handler"
     timeout_exception = TimeoutError
     sleep_func = time.sleep


### PR DESCRIPTION
`implementer` decorator does not work on classes before zope.interface
3.6.0. Ubuntu Lucid ships with zope.interface 3.5.3. This commit
replaces the use of `implementer` decorators by the old way to declare
an implementation.

Of course, maybe compatibility with Ubuntu Lucid is not important enough to change a clean decorator in some crappy function call.
