### PR TITLE
Support CLASSPATH when initializing ZooKeeper for tests

### DIFF
--- a/kazoo/testing/common.py
+++ b/kazoo/testing/common.py
@@ -147,6 +147,8 @@ log4j.appender.ROLLINGFILE.File=""" + (
             jars.extend(glob(os.path.join(
                 self.install_path,
                 "build/lib/*.jar")))
+        if 'CLASSPATH' in os.environ:
+            jars.append(os.environ['CLASSPATH'])
         return ":".join(jars)
 
     @property


### PR DESCRIPTION
On certain setups (for example on vanilla Debian squeeze with system packages) the testing with ZooKeeper cluster fails in not finding the log4j1.2, even though that is installed under `/usr/share/java`. Reason is the code searches for `lib/*.jar` and does not include jar files in `ZOOKEEPER_HOME`.

However, instead of changing or adding more jars to the mix, this adds support for defining `CLASSPATH` as environment value and respecting it when constructing the classpath for `-cp` 
