### PR TITLE
Reset watchers on lost connection

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -223,11 +223,14 @@ class KazooClient(object):
         """Resets a variety of client states for a new connection."""
         self._queue = deque()
         self._pending = deque()
-        self._child_watchers = defaultdict(list)
-        self._data_watchers = defaultdict(list)
 
+        self._reset_watchers()
         self._reset_session()
         self.last_zxid = 0
+
+    def _reset_watchers(self):
+        self._child_watchers = defaultdict(list)
+        self._data_watchers = defaultdict(list)
 
     def _reset_session(self):
         self._session_id = None
@@ -335,6 +338,7 @@ class KazooClient(object):
             self._live.clear()
             self._notify_pending(state)
             self._make_state_change(KazooState.SUSPENDED)
+            self._reset_watchers()
 
     def _notify_pending(self, state):
         """Used to clear a pending response queue and request queue


### PR DESCRIPTION
This likely isn't the correct fix, but found this issue while testing DataWatch.
Against a single zk server, client._data_watchers accumulate with each restart
of the zk server.  After restarting the zk server, a DataWatch callback for given
path will be called twice.  Restart again, called three times, and so on.

Without the client.py change to reset_watchers, you should see the following:
$ ZOOKEEPER_PATH=$PWD/bin/zookeeper ./bin/nosetests kazoo.tests.test_watchers:KazooDataWatcherRestartTests.test_data_watcher

  File "/.../kazoo/kazoo/tests/test_watchers.py", line 507, in test_data_watcher
    eq_(len(events), 2)
AssertionError: 3 != 2
