### PR TITLE
Tweaks to make KazooClient.stop() less likely to raise an exception

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -168,6 +168,7 @@ class KazooClient(object):
             self._reset_session()
 
         # ZK uses milliseconds
+        self._timeout = timeout
         self._session_timeout = int(timeout * 1000)
 
         # We use events like twitter's client to track current and
@@ -369,9 +370,10 @@ class KazooClient(object):
 
     def _safe_close(self):
         self.handler.stop()
-        if not self._connection.stop(10):
+        if not self._connection.stop(self._timeout):
             raise Exception("Writer still open from prior connection"
-                            " and wouldn't close after 10 seconds")
+                            " and wouldn't close after %s seconds" %
+                            self._timeout)
 
     def _call(self, request, async_object):
         """Ensure there's an active connection and put the request in

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -491,6 +491,10 @@ class ConnectionHandler(object):
                             self.ping_outstanding.clear()
                             raise ConnectionDropped(
                                 "outstanding heartbeat ping not received")
+                        if self.client._stopped.is_set():
+                            log.debug("client has stopped, breaking out of "
+                                      "_connect_loop")
+                            break
                         self._send_ping(connect_timeout)
                     elif s[0] == self._socket:
                         response = self._read_socket(read_timeout)
@@ -534,6 +538,8 @@ class ConnectionHandler(object):
             log.debug('    Using session_id: %r session_passwd: %s',
                       client._session_id,
                       hexlify(client._session_passwd))
+
+        self._socket.settimeout(client._session_timeout / 1000.0 * 0.67)
 
         with self._socket_error_handling():
             self._socket.connect((host, port))


### PR DESCRIPTION
Three changes, all of which are intended to make the "Writer still open"
exception less likely to fire.

1) Adjust _safe_close timeout to match session_timeout, so that clients
which have adjusted the master timeout higher won't stop() timeout while
an inner timeout is still sleeping.

2) Add a breakout point to _connect_loop so that if a client has been
stopped, we don't keep waiting on a dead socket

3) Set a socket timeout on the initial connect to remote endpoints so
that we don't sit around waiting a ton of time for a dead endpoint to
respond.  The modifier on session_timeout was chosen arbitrarily.
# Context

Kazoo clients handle remote zookeeper hosts which have died in a very
bad way.  To reproduce the issues we've been seeing, start up a
Zookeeper server on a virtual machine, connect using Kazoo, then
pull the power plug on the virtual machine.  Now call stop() on the
kazoo client.  It will always raise the "Writer still open" exception,
because the Connection instance is stuck either in the _connect_loop
select loop or in the _connect waiting for a socket connection to
something that will never come around.  As far as I could tell, the
underlying Connection never really recovered and cleaned itself up, and
further calls to stop() on the client are no-ops because the client
stopped flag is still set.

Fixes 2 and 3 allow me to call stop() at any point while trying to
connect to an invalid ip / previously valid IP and have the stop()
return successfully within the timeout. Fix #1 I put in because for some
very large timeouts (60s+?) you could have an inner timeout that is
longer than 10s, so you'd pretty much never be able to call stop()
successfully if you weren't actively connected to Zookeeper.
