### PR TITLE
Do not throw a CancelledError when acquire() is called after a cancel() has been called.

### DIFF
--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -332,6 +332,10 @@ class Semaphore(object):
         .. versionadded:: 1.1
             The blocking argument and the max_leases check.
         """
+        # If the semaphore had previously been cancelled, make sure to
+        # reset that state.
+        self.cancelled = False
+
         try:
             self.is_acquired = self.client.retry(self._inner_acquire,
                                                  blocking=blocking)

--- a/kazoo/tests/test_lock.py
+++ b/kazoo/tests/test_lock.py
@@ -382,3 +382,11 @@ class TestSemaphore(KazooTestCase):
         lock.release()
         lock.acquire()
         lock.release()
+
+    def test_acquire_after_cancelled(self):
+        lock = self.client.Semaphore(self.lockpath)
+        self.assertTrue(lock.acquire())
+        self.assertTrue(lock.release())
+        lock.cancel()
+        self.assertTrue(lock.cancelled)
+        self.assertTrue(lock.acquire())


### PR DESCRIPTION
Patch for issue #87: Reset the Semaphore.cancelled state to False when someone intentionally calls Semaphore.acquire(). Regardless of whether or not the user has called cancel(), if they call acquire() they probably want to acquire the lease.
