### PR TITLE
add timeout param to Lock

### DIFF
--- a/kazoo/exceptions.py
+++ b/kazoo/exceptions.py
@@ -29,6 +29,10 @@ class ConnectionDropped(KazooException):
     """Internal error for jumping out of loops"""
 
 
+class LockTimeout(KazooException):
+    """ Raised if failed to acquire a lock """
+
+
 def _invalid_error_code():
     raise RuntimeError('Invalid error code')
 


### PR DESCRIPTION
Instead of blocking forever on a lock, optionally specify a timeout and raise a LockTimeout exception if we don't acquire the lock within that time.
