### PR TITLE
fix pipe leftover data

### DIFF
--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -388,6 +388,12 @@ class ConnectionHandler(object):
             # Not actually something on the queue, this can occur if
             # something happens to cancel the request such that we
             # don't clear the pipe below after sending
+            try:
+                # Clear possible inconsistence (no request in the queue
+                # but have data in the read pipe), which causes cpu to spin.
+                os.read(self._read_pipe, 1)
+            except OSError:
+                pass
             return
 
         # Special case for auth packets


### PR DESCRIPTION
I found the kazoo client can make cpu usage jump to 100% in certain situation. 

I traced down the problem to be an inconsistency where there is no write request in the queue but there is data in the read-pipe. In this situation, the kazoo-client entered an unrecoverable loop which kept polling the ready read-pipe but failed to clear it causing cpu to busy spin.
