### PR TITLE
Handle non-deserializable connect response

### DIFF
--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -233,7 +233,16 @@ class ConnectionHandler(object):
         msg = self._read(length, timeout)
 
         if hasattr(request, 'deserialize'):
-            obj, _ = request.deserialize(msg, 0)
+            try:
+                obj, _ = request.deserialize(msg, 0)
+            except Exception as exc:
+                if self.log_debug:
+                    log.debug("Exception raised during deserialization"
+                              " of request: %s", request)
+                log.exception(exc)
+
+                # raise ConnectionDropped so connect loop will retry
+                raise ConnectionDropped('invalid server response')
             log.debug('Read response %s', obj)
             return obj, zxid
 


### PR DESCRIPTION
This attempts to defend against a problem we have seen sporadically in production but the exact cause of which is not clear. Occasionally the client receives a connect response that it cannot deserialize. This results in an error and leaves the client in a zombie state where it no longer attempts to reconnect.

Seen with kazoo 0.9:

```
2013-05-20 16:14:44,155 ERROR Dummy-7 kazoo.protocol.connection:479 unpack_from requires a buffer of at least 16 bytes 
   ----- exception: unpack_from requires a buffer of at least 16 bytes ----- 
9-py2.7.egg/kazoo/protocol/connection.py:431 read_timeout, connect_timeout = self._connect(host, port) 
9-py2.7.egg/kazoo/protocol/connection.py:506 connect_result, zxid = self._invoke(client._session_timeout, connect) 
9-py2.7.egg/kazoo/protocol/connection.py:213 obj, _ = request.deserialize(msg, 0) 
y2.7.egg/kazoo/protocol/serialization.py:106 bytes, offset) 
```

With this change we catch deserialization errors and raise a ConnectionDropped error. This is caught by the outer connection loop and the client continues attempting to reconnect. If there are no objections I will merge once tests pass.
