### PR TITLE
Fixes KazooTestHarness on Windows

### DIFF
--- a/kazoo/testing/common.py
+++ b/kazoo/testing/common.py
@@ -49,7 +49,8 @@ def debug(sig, frame):
 
 
 def listen():
-    signal.signal(signal.SIGUSR1, debug)  # Register handler
+    if os.name != 'nt':  # SIGUSR1 is not supported on Windows
+        signal.signal(signal.SIGUSR1, debug)  # Register handler
 listen()
 
 if os.name == 'nt':


### PR DESCRIPTION
Discussion takes place in issue #91.

Changes are:
- modifies the path written inside the log4j.properties and zoo.cfg files so they are handled by java on Windows. 
- Uses classpath separator `;` on Windows as opposed to `:` on Unix.
- Disables interactive console activated with SIGUSR1 signal, not available on Windows

Unfortunately, starting with 1.0b1, it only leads to the error reported in issue #78 more rapidly. It can be used to test any version before.
