### PR TITLE
testing: allow kazoo to properly start zookeeper on Debian/Ubuntu

### DIFF
--- a/kazoo/testing/common.py
+++ b/kazoo/testing/common.py
@@ -169,6 +169,15 @@ log4j.appender.ROLLINGFILE.File=""" + to_java_compatible_path(
             jars.extend(glob(os.path.join(
                 self.install_path,
                 "lib/*.jar")))
+            jars.extend(glob(os.path.join(
+                self.install_path,
+                "log4j-*.jar")))
+            jars.extend(glob(os.path.join(
+                self.install_path,
+                "slf4j-api-*.jar")))
+            jars.extend(glob(os.path.join(
+                self.install_path,
+                "slf4j-log4j*.jar")))
         else:
             # Development build (plain `ant`)
             jars = glob((os.path.join(


### PR DESCRIPTION
On Debian/Ubuntu, recent versions of zookeeper need to load slf4j to
work as expected. Otherwise, we get this error message on start:

```
Exception Exception in thread "main" in thread "main" Exception in thread "main" java.lang.NoClassDefFoundError: org/slf4j/LoggerFactoryjava.lang.NoClassDefFoundError: org/slf4j/LoggerFactory

        at org.apache.zookeeper.server.quorum.QuorumPeerMain.<clinit>(QuorumPeerMain.java:64)
        at org.apache.zookeeper.server.quorum.QuorumPeerMain.<clinit>(QuorumPeerMain.java:64)
java.lang.NoClassDefFoundError: org/slf4j/LoggerFactory
Caused by: java.lang.ClassNotFoundException: org.slf4j.LoggerFactory
        at org.apache.zookeeper.server.quorum.QuorumPeerMain.<clinit>(QuorumPeerMain.java:64)Caused by: java.lang.ClassNotFoundException: org.slf4j.LoggerFactory at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
```
