### PR TITLE
make it easier to tell where a traceback came from

### DIFF
--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -200,9 +200,8 @@ class SequentialThreadingHandler(object):
                         if func is _STOP:
                             break
                         func()
-                    except Exception as exc:
-                        log.warning("Exception in worker queue thread")
-                        log.exception(exc)
+                    except Exception:
+                        log.exception("Exception in worker queue thread")
                     finally:
                         queue.task_done()
                 except Queue.Empty:

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -517,8 +517,8 @@ class ConnectionHandler(object):
             except RWServerAvailable:
                 self.logger.warning('Found a RW server, dropping connection')
                 client._session_callback(KeeperState.CONNECTING)
-            except Exception as e:
-                self.logger.exception(e)
+            except Exception:
+                self.logger.exception('Unhandled exception in connection loop')
                 raise
             finally:
                 self._socket.close()


### PR DESCRIPTION
log.exception already loads the exc_info, so there's no need to pass it
into the exception method; instead, use the message to indicate where
the exception was detected.
