### PR TITLE
Consider connection state changed events as valid and inform the client

### DIFF
--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -52,10 +52,16 @@ _CONNECTION_DROP = object()
 
 STOP_CONNECTING = object()
 
+NONE_EVENT = -1
 CREATED_EVENT = 1
 DELETED_EVENT = 2
 CHANGED_EVENT = 3
 CHILD_EVENT = 4
+
+KEEPER_STATES_MAP = {
+    3: KeeperState.CONNECTED,
+    5: KeeperState.CONNECTED_RO,
+}
 
 WATCH_XID = -1
 PING_XID = -2
@@ -310,6 +316,9 @@ class ConnectionHandler(object):
             watchers.extend(client._child_watchers.pop(path, []))
         elif watch.type == CHILD_EVENT:
             watchers.extend(client._child_watchers.pop(path, []))
+        elif watch.type == NONE_EVENT and watch.state in KEEPER_STATES_MAP:
+            client._session_callback(KEEPER_STATES_MAP[watch.state])
+            return
         else:
             self.logger.warn('Received unknown event %r', watch.type)
             return


### PR DESCRIPTION
ZooKeeper's Java client implementation considers connection state WatchedEvents
as valid. See src/java/main/org/apache/zookeeper/ClientCnxn.java#L416.

This is needed for upcoming changes like https://issues.apache.org/jira/browse/ZOOKEEPER-1607
in which an Observer will be able to change from CONNECTED to CONNECTED_RO without
dropping clients.

It shouldn't introduce any other side effects.
