### PR TITLE
Add IPv6 support to kazoo

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -559,10 +559,8 @@ class KazooClient(object):
         if not self._live.is_set():
             raise ConnectionLoss("No connection to server")
 
-        sock = self.handler.socket()
-        sock.settimeout(self._session_timeout)
         peer = self._connection._socket.getpeername()
-        sock.connect(peer)
+        sock = self.handler.create_connection(peer, timeout=self._session_timeout)
         sock.sendall(cmd)
         result = sock.recv(8192)
         sock.close()

--- a/kazoo/handlers/gevent.py
+++ b/kazoo/handlers/gevent.py
@@ -16,7 +16,7 @@ from gevent.queue import Queue
 from gevent import socket
 from zope.interface import implementer
 
-from kazoo.handlers.utils import create_tcp_socket
+from kazoo.handlers.utils import create_tcp_socket, create_tcp_connection
 from kazoo.interfaces import IAsyncResult
 from kazoo.interfaces import IHandler
 
@@ -118,6 +118,9 @@ class SequentialGeventHandler(object):
 
     def socket(self, *args, **kwargs):
         return create_tcp_socket(socket)
+
+    def create_connection(self, *args, **kwargs):
+        return create_tcp_connection(socket, *args, **kwargs)
 
     def event_object(self):
         """Create an appropriate Event object"""

--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -26,7 +26,7 @@ except ImportError:  # pragma: nocover
 
 from zope.interface import implementer
 
-from kazoo.handlers.utils import create_tcp_socket
+from kazoo.handlers.utils import create_tcp_socket, create_tcp_connection
 from kazoo.interfaces import IAsyncResult
 from kazoo.interfaces import IHandler
 
@@ -253,6 +253,9 @@ class SequentialThreadingHandler(object):
 
     def socket(self):
         return create_tcp_socket(socket)
+
+    def create_connection(self, *args, **kwargs):
+        return create_tcp_connection(socket, *args, **kwargs)
 
     def event_object(self):
         """Create an appropriate Event object"""

--- a/kazoo/hosts.py
+++ b/kazoo/hosts.py
@@ -1,5 +1,5 @@
 import random
-
+from urlparse import urlsplit
 
 class HostIterator(object):
     """An iterator that returns selected hosts in order.
@@ -36,9 +36,12 @@ def collect_hosts(hosts, randomize=True):
 
     result = []
     for host_port in host_ports.split(","):
-        host, port = host_port.partition(":")[::2]
-        port = int(port.strip()) if port else 2181
-        result.append((host.strip(), port))
+        # put all complexity of dealing with
+        # IPv4 & IPv6 address:port on the urlsplit
+        res = urlsplit("xxx://" + host_port)
+        host = res.hostname
+        port = int(res.port) if res.port else 2181
+        result.append((host, port))
     if randomize:
         return (RandomHostIterator(result), chroot)
     return (HostIterator(result), chroot)

--- a/kazoo/interfaces.py
+++ b/kazoo/interfaces.py
@@ -51,6 +51,10 @@ class IHandler(Interface):
         """A socket method that implements Python's socket.socket
         API"""
 
+    def create_connection():
+        """A socket method that implements Python's
+        socket.create_connection API"""
+
     def event_object():
         """Return an appropriate object that implements Python's
         threading.Event API"""

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -86,9 +86,9 @@ class RWPinger(object):
     the iterator will yield False if called too soon.
 
     """
-    def __init__(self, hosts, socket_func, socket_handling):
+    def __init__(self, hosts, connection_func, socket_handling):
         self.hosts = hosts
-        self.socket = socket_func
+        self.connection = connection_func
         self.last_attempt = None
         self.socket_handling = socket_handling
 
@@ -105,12 +105,11 @@ class RWPinger(object):
             # Skip rw ping checks if its too soon
             return False
         for host, port in self.hosts:
-            sock = self.socket()
             log.debug("Pinging server for r/w: %s:%s", host, port)
             self.last_attempt = time.time()
             try:
                 with self.socket_handling():
-                    sock.connect((host, port))
+                    sock = self.connection((host, port))
                     sock.sendall(b"isro")
                     result = sock.recv(8192)
                     sock.close()
@@ -200,7 +199,7 @@ class ConnectionHandler(object):
     def _server_pinger(self):
         """Returns a server pinger iterable, that will ping the next
         server in the list, and apply a back-off between attempts."""
-        return RWPinger(self.client.hosts, self.handler.socket,
+        return RWPinger(self.client.hosts, self.handler.create_connection,
                         self._socket_error_handling)
 
     def _read_header(self, timeout):
@@ -494,9 +493,8 @@ class ConnectionHandler(object):
         TimeoutError = self.handler.timeout_exception
         close_connection = False
 
+        self._socket = None
         host, port = advance_iterator(hosts)
-
-        self._socket = self.handler.socket()
 
         # Were we given a r/w server? If so, use that instead
         if self._rw_server:
@@ -570,9 +568,9 @@ class ConnectionHandler(object):
                           client._session_id,
                           hexlify(client._session_passwd))
 
-        self._socket.settimeout(client._session_timeout)
         with self._socket_error_handling():
-            self._socket.connect((host, port))
+            self._socket = self.handler.create_connection((host, port),
+                                client._session_timeout)
 
         self._socket.setblocking(0)
 


### PR DESCRIPTION
Kazoo lacks IPv6 support which makes it difficult to use it in our company, where zookeeper lives on IPv6 addresses only. Looks like it's a right time to teach kazoo some IPv6.

UPDATE:
Almost forgot to describe an interface:

``` python
zk = KazooClient(hosts='[fe80::1%lo0]:2181, 127.0.0.1:2181, etc')
```
