### PR TITLE
sphinx: Configure sys.path to allow autodoc to find Kazoo.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,6 +10,7 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
+import os
 import sys
 
 
@@ -27,7 +28,7 @@ for mod_name in MOCK_MODULES:
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration -----------------------------------------------------
 


### PR DESCRIPTION
Previously, if Kazoo wasn't already in sys.path otherwise (e.g. if not
installed) sphinx autodoc wouldn't be able to find the module for
documenting purposes because sphinx-build happens in an adjacent
subdirectory.

This adds the docs folder's parent to the path so that autodoc can find
the Kazoo module properly and do its stuff.
