### PR TITLE
Limit the backends we use for SLF4J

### DIFF
--- a/kazoo/testing/common.py
+++ b/kazoo/testing/common.py
@@ -175,7 +175,10 @@ log4j.appender.ROLLINGFILE.File=""" + to_java_compatible_path(
                 "log4j-*.jar")))
             jars.extend(glob(os.path.join(
                 self.install_path,
-                "slf4j-*.jar")))
+                "slf4j-api-*.jar")))
+            jars.extend(glob(os.path.join(
+                self.install_path,
+                "slf4j-log4j-*.jar")))
         else:
             # Development build (plain `ant`)
             jars = glob((os.path.join(


### PR DESCRIPTION
Using KazooTestCase becomes really chatty if you happen to have other
backends than just log4j installed for slf4j. Limiting only to
slf4j-log4j-\* ensures that the properties file we provide when
starting zookeeper is enough to turn off the chatter.
