### PR TITLE
client: Raise exception when calling create on closed client

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -788,8 +788,15 @@ class KazooClient(object):
 
         async_result = self.handler.async_result()
 
+        @capture_exceptions(async_result)
         def do_create():
-            self._create_async_inner(path, value, acl, flags, trailing=sequence).rawlink(create_completion)
+            result = self._create_async_inner(path, value, acl, flags, trailing=sequence)
+            if result.exception is not None:
+                # Closed connection might have set the exception for
+                # the async_result object. If that is the case, we'll
+                # raise the exception immediately
+                raise result.exception
+            result.rawlink(create_completion)
 
         @capture_exceptions(async_result)
         def retry_completion(result):

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -342,6 +342,14 @@ class TestClient(KazooTestCase):
         eq_(path, "/1")
         self.assertTrue(client.exists("/1"))
 
+    def test_create_on_closed_connection(self):
+        client = self.client
+        client.stop()
+        client.close()
+
+        self.assertRaises(ConnectionClosedError, client.create,
+                          '/closedpath', 'bar')
+
     def test_create_unicode_path(self):
         client = self.client
         path = client.create(u("/ascii"))


### PR DESCRIPTION
If the client is closed the completion queue is never emptied and thus
the create_completion callback for create_async is never called.

This causes a deadlock/zombie thread in the code when trying to call
create, as it keeps on waiting the condition which will never get
notified.

This patch will check if the async_result from _create_async_inner gets
exception set immediately and propagate that one to the caller of
create_async.

Thanks to @jclopes for helping to solve this
