### PR TITLE
Fix handling of IPv6 hosts in command

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -598,7 +598,7 @@ class KazooClient(object):
         if not self._live.is_set():
             raise ConnectionLoss("No connection to server")
 
-        peer = self._connection._socket.getpeername()
+        peer = self._connection._socket.getpeername()[:2]
         sock = self.handler.create_connection(
             peer, timeout=self._session_timeout / 1000.0)
         sock.sendall(cmd)


### PR DESCRIPTION
The command method in the client fails to create a socket for IPv6 hosts.  The problem is that create_connection expects a 2-tuple of (addr, port) for both IPv4 and IPv6, but, getpeername returns a 4-tuple of (addr, port, flow, scope) for IPv6 sockets.  Slicing out the first 2 items fixes this problem and works fine in either case.
