### PR TITLE
Fix the order of exceptions in Lock.aquire

### DIFF
--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -112,7 +112,6 @@ class Lock(object):
             self.cancelled = False
             raise
 
-
         if not self.is_acquired:
             self._delete_node(self.node)
 


### PR DESCRIPTION
The error: Lock.acquire: Bad except clauses order (KazooException is an ancestor class of RetryFailedError) was reported by pylint. The RetryFailedError path would never be executed, leading to a wrong flag set in case of cancelation, for example.
