### PR TITLE
Make add_auth and add_auth_async consistent with the rest of the API

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -625,8 +625,16 @@ class KazooClient(object):
         :param scheme: authentication scheme (default supported:
                        "digest").
         :param credential: the credential -- value depends on scheme.
+
+        :returns: True if it was successful.
+        :rtype: bool
+
+        :raises:
+            :exc:`~kazoo.exceptions.AuthFailedError` if it failed though
+            the session state will be set to AUTH_FAILED as well.
+
         """
-        return self.add_auth_async(scheme, credential)
+        return self.add_auth_async(scheme, credential).get()
 
     def add_auth_async(self, scheme, credential):
         """Asynchronously send credentials to server. Takes the same
@@ -639,8 +647,10 @@ class KazooClient(object):
             raise TypeError("Invalid type for scheme")
         if not isinstance(credential, basestring):
             raise TypeError("Invalid type for credential")
-        self._call(Auth(0, scheme, credential), None)
-        return True
+
+        async_result = self.handler.async_result()
+        self._call(Auth(0, scheme, credential), async_result)
+        return async_result
 
     def unchroot(self, path):
         """Strip the chroot if applicable from the path."""

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -193,6 +193,22 @@ class TestConnection(KazooTestCase):
         self.assertRaises(TypeError, self.client.add_auth,
             None, ('user', 'pass'))
 
+    def test_async_auth(self):
+        username = uuid.uuid4().hex
+        password = uuid.uuid4().hex
+        digest_auth = "%s:%s" % (username, password)
+        result = self.client.add_auth_async("digest", digest_auth)
+        self.assertTrue(result.get())
+
+    def test_async_auth_failure(self):
+        from kazoo.exceptions import AuthFailedError
+
+        username = uuid.uuid4().hex
+        password = uuid.uuid4().hex
+        digest_auth = "%s:%s" % (username, password)
+
+        self.assertRaises(AuthFailedError, self.client.add_auth, "unknown-scheme", digest_auth)
+
     def test_session_expire(self):
         from kazoo.protocol.states import KazooState
 


### PR DESCRIPTION
Even though ZK closes the connection when auth fails (though the session is
still valid!) it is nicer to have add_auth be consistent with the rest
of the API by setting an exception on the AsyncResult object. It is
also more consisent if the sync version has a return value as well (i.e.: True)
or an exception raised when it fails.

We still switch the state to KeeperState.AUTH_FAILED after failing (since the conexion
is closed by the server).

This change doesn't break the current behavior (except for adding the return
values which shouldn't break anything). It also makes the API docs correct :-)
