### PR TITLE
Allow passing dictionaries to KazooClient.__init__() for connection_retry and command_retry

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -208,17 +208,25 @@ class KazooClient(object):
 
         self.retry = self._conn_retry = None
 
-        if connection_retry is not None:
+        if type(connection_retry) is dict:
+            self._conn_retry = KazooRetry(**connection_retry)
+        elif type(connection_retry) is KazooRetry:
             self._conn_retry = connection_retry
+
+        if type(command_retry) is dict:
+            self.retry = KazooRetry(**command_retry)
+        elif type(command_retry) is KazooRetry:
+            self.retry = command_retry
+
+        if type(self._conn_retry) is KazooRetry:
             if self.handler.sleep_func != self._conn_retry.sleep_func:
                 raise ConfigurationError("Retry handler and event handler "
                                          " must use the same sleep func")
 
-        if command_retry is not None:
-            self.retry = command_retry
+        if type(self.retry) is KazooRetry:
             if self.handler.sleep_func != self.retry.sleep_func:
-                raise ConfigurationError("Command retry handler and event handler "
-                                         " must use the same sleep func")
+                raise ConfigurationError("Command retry handler and event "
+                                         "handler must use the same sleep func")
 
         if self.retry is None or self._conn_retry is None:
             old_retry_keys = dict(_RETRY_COMPAT_DEFAULTS)

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -94,6 +94,14 @@ class TestClientConstructor(unittest.TestCase):
         timeout = client.handler.timeout_exception
         self.assertRaises(timeout, client.start, 0.1)
 
+    def test_retry_options_dict(self):
+        from kazoo.retry import KazooRetry
+        client = self._makeOne(command_retry=dict(max_tries=99),
+                               connection_retry=dict(delay=99))
+        self.assertTrue(type(client._conn_retry) is KazooRetry)
+        self.assertTrue(type(client.retry) is KazooRetry)
+        eq_(client.retry.max_tries, 99)
+        eq_(client._conn_retry.delay, 99)
 
 class TestConnection(KazooTestCase):
     def _makeAuth(self, *args, **kwargs):


### PR DESCRIPTION
Per the code documentation:

```
:param connection_retry:
    A :class:`kazoo.retry.KazooRetry` object to use for
    retrying the connection to Zookeeper. Also can be a dict of
    options which will be used for creating one.
:param command_retry:
    A :class:`kazoo.retry.KazooRetry` object to use for
    the :meth:`KazooClient.retry` method. Also can be a dict of
    options which will be used for creating one.
```

The useful feature of passing in a `dict` in place of a `KazooRetry` was not working correctly due to the way that `KazooClient.__init__()` was handling the `connection_retry` and `command_retry` kwargs. This patch fixes the issue and keeps the code documentation honest.
