### PR TITLE
Empty list acl param should be consistent between public methods

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -770,6 +770,7 @@ class KazooClient(object):
             returns a non-zero error code.
 
         """
+        acl = acl or self.default_acl
         return self.create_async(path, value, acl=acl, ephemeral=ephemeral,
             sequence=sequence, makepath=makepath).get()
 

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -449,6 +449,13 @@ class TestClient(KazooTestCase):
         version = client.server_version()
         self.assertEqual(len(acls), 1 if version > (3, 4) else 2)
 
+    def test_create_acl_empty_list(self):
+        from kazoo.security import OPEN_ACL_UNSAFE
+        client = self.client
+        client.create("/1", acl=[])
+        acls, stat = client.get_acls("/1")
+        self.assertEqual(acls, OPEN_ACL_UNSAFE)
+
     def test_version_no_connection(self):
         @raises(ConnectionLoss)
         def testit():


### PR DESCRIPTION
In ensure_path() you can pass acl=[] and it is set to default_acl. Whereas in
create(), acl=None gets you default_acl but acl=[] gets you an InvalidACLError.

Here is the new test case for acl=[] without the change in create():

```
$ bin/nosetests -s -d kazoo.tests.test_client:TestClient.test_create_acl_empty_list

ERROR: test_create_acl_empty_list (kazoo.tests.test_client.TestClient)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "../kazoo/tests/test_client.py", line 455, in test_create_acl_empty_list
    client.create("/1", acl=[])
  File "../kazoo/client.py", line 775, in create
    sequence=sequence, makepath=makepath).get()
  File "../kazoo/handlers/threading.py", line 107, in get
    raise self._exception
InvalidACLError: ((), {})
```

And with the change in create() (i.e.: do as ensure_path() does):

```
$ bin/nosetests -s -d kazoo.tests.test_client:TestClient.test_create_acl_empty_list
.
----------------------------------------------------------------------
Ran 1 test in 2.112s

OK
```

Signed-off-by: Raul Gutierrez S rgs@itevenworks.net
