### PR TITLE
Don't treat null (or None) data as ""

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -792,7 +792,7 @@ class KazooClient(object):
         if acl and (isinstance(acl, ACL) or
                     not isinstance(acl, (tuple, list))):
             raise TypeError("acl must be a tuple/list of ACL's")
-        if not isinstance(value, bytes):
+        if value is not None and not isinstance(value, bytes):
             raise TypeError("value must be a byte string")
         if not isinstance(ephemeral, bool):
             raise TypeError("ephemeral must be a bool")
@@ -1164,7 +1164,7 @@ class KazooClient(object):
         """
         if not isinstance(path, basestring):
             raise TypeError("path must be a string")
-        if not isinstance(value, bytes):
+        if value is not None and not isinstance(value, bytes):
             raise TypeError("value must be a byte string")
         if not isinstance(version, int):
             raise TypeError("version must be an int")

--- a/kazoo/protocol/serialization.py
+++ b/kazoo/protocol/serialization.py
@@ -54,7 +54,7 @@ def write_string(bytes):
 
 
 def write_buffer(bytes):
-    if not bytes:
+    if bytes is None:
         return int_struct.pack(-1)
     else:
         return int_struct.pack(len(bytes)) + bytes
@@ -64,7 +64,7 @@ def read_buffer(bytes, offset):
     length = int_struct.unpack_from(bytes, offset)[0]
     offset += int_struct.size
     if length < 0:
-        return b'', offset
+        return None, offset
     else:
         index = offset
         offset += length

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -390,6 +390,18 @@ class TestClient(KazooTestCase):
         self.assertRaises(ConnectionClosedError, client.create,
                           '/closedpath', b'bar')
 
+    def test_create_null_data(self):
+        client = self.client
+        client.create("/nulldata", None)
+        value, _ = client.get("/nulldata")
+        self.assertEqual(value, None)
+
+    def test_create_empty_string(self):
+        client = self.client
+        client.create("/empty", "")
+        value, _ = client.get("/empty")
+        eq_(value, "")
+
     def test_create_unicode_path(self):
         client = self.client
         path = client.create(u("/ascii"))
@@ -700,6 +712,20 @@ class TestClient(KazooTestCase):
         data, stat2 = client.get('a')
         self.assertEqual(data, b'second')
         self.assertEqual(stat, stat2)
+
+    def test_set_null_data(self):
+        client = self.client
+        client.create("/nulldata", "not none")
+        client.set("/nulldata", None)
+        value, _ = client.get("/nulldata")
+        self.assertEqual(value, None)
+
+    def test_set_empty_string(self):
+        client = self.client
+        client.create("/empty", "not empty")
+        client.set("/empty", "")
+        value, _ = client.get("/empty")
+        eq_(value, "")
 
     def test_set_invalid_arguments(self):
         client = self.client


### PR DESCRIPTION
In ZK's Java impl if the data is null, it'll be serialized
with length equals -1. If it is an empty string, it'll be serialized
with length equals 0.

Currently, Kazoo treats data with a length of -1 as "". This diff
changes it so that it'll come back as None. Same thing for creating
and setting data to None. Tests added.

Reported-by: Grant Monroe tnarg@twitter.com
Signed-off-by: Raul Gutierrez S rgs@itevenworks.net
