### PR TITLE
Only close if not None

### DIFF
--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -192,8 +192,10 @@ class ConnectionHandler(object):
         self.connection_closed.set()
         wp, rp = self._write_pipe, self._read_pipe
         self._write_pipe = self._read_pipe = None
-        os.close(wp)
-        os.close(rp)
+        if wp is not None:
+            os.close(wp)
+        if rp is not None:
+            os.close(rp)
 
     def _server_pinger(self):
         """Returns a server pinger iterable, that will ping the next


### PR DESCRIPTION
If a user calls close from a client on a client
which was never started with its nice to just
do nothing instead of throwing a type error which
is what happens if os.close recieves a None type.

Fixes: Issue  #167
