### PR TITLE
connection: Set closed state when zk_loop stops

### DIFF
--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -468,9 +468,9 @@ class ConnectionHandler(object):
         except RetryFailedError:
             self.logger.warning("Failed connecting to Zookeeper "
                                 "within the connection retry policy.")
-            self.client._session_callback(KeeperState.CLOSED)
         finally:
             self.connection_stopped.set()
+            self.client._session_callback(KeeperState.CLOSED)
             self.logger.log(BLATHER, 'Connection stopped')
 
     def _connect_loop(self, retry):


### PR DESCRIPTION
Calling client.stop() for a client does not always set the client state
KeeperState.CLOSED. This can lead into a situation that client keeps
raising SessionExpired even if the client is actually stopped. This in
turn makes for example ChildrenWatch unable to stop, halting the
handler's stop call too while joining the threads.
