### PR TITLE
Queue.get() no longer does get_children() and sorted() on every call

### DIFF
--- a/kazoo/recipe/queue.py
+++ b/kazoo/recipe/queue.py
@@ -82,7 +82,7 @@ class Queue(BaseQueue):
             self._children = list(sorted(self._children))
         if not self._children:
             return None
-        name = self._children.pop(0)
+        name = self._children[0]
         try:
             data, stat = self.client.get(self.path + "/" + name)
         except NoNodeError:  # pragma: nocover
@@ -96,6 +96,7 @@ class Queue(BaseQueue):
             # the node in the meantime. consider the item as processed
             # by the other process
             raise ForceRetryError()
+        self._children.pop(0)
         return data
 
     def put(self, value, priority=100):


### PR DESCRIPTION
If the queue contains a large number of elements (> 10000), each `Queue.get()` will take a lot of time (>0.1sec.) due to frequent `get_children()` and `sorted()`.
Recips say that the call of `get_children() every time is not necessary:
https://zookeeper.apache.org/doc/r3.1.2/recipes.html#sc_recipes_Queues

```
 The client does not need to issue another getChildren( ) until it exhausts the list obtained from the first getChildren( ) call.
```

This patch implements this feature.
