### PR TITLE
Fixed pipes leaking into child processes, closes #169.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Bug Handling
   parent exception before the child. Patch by ReneSac.
 - Fix issue with client.stop() not always setting the client state to
   KeeperState.CLOSED. Patch by Jyrki Pulliainen in PR #174.
+- Issue #169: Fixed pipes leaking into child processes.
 
 API Changes
 ***********

--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -9,11 +9,15 @@ import functools
 import os
 
 
+def _set_fd_cloexec(fd):
+    flags = fcntl.fcntl(fd, fcntl.F_GETFD)
+    fcntl.fcntl(fd, fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
+
+
 def _set_default_tcpsock_options(module, sock):
     sock.setsockopt(module.IPPROTO_TCP, module.TCP_NODELAY, 1)
     if HAS_FNCTL:
-        flags = fcntl.fcntl(sock, fcntl.F_GETFD)
-        fcntl.fcntl(sock, fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
+        _set_fd_cloexec(sock)
     return sock
 
 
@@ -24,6 +28,8 @@ def create_pipe():
     if HAS_FNCTL:
         fcntl.fcntl(r, fcntl.F_SETFL, os.O_NONBLOCK)
         fcntl.fcntl(w, fcntl.F_SETFL, os.O_NONBLOCK)
+        _set_fd_cloexec(r)
+        _set_fd_cloexec(w)
     return r, w
 
 


### PR DESCRIPTION
Use FD_CLOEXEC on the r/w pipe as well.

O_CLOEXEC or pipe2 aren't available in most Python versions, so I didn't try to use those. The real fix will be done automagically in Python 3.4 via http://docs.python.org/3.4/whatsnew/3.4.html#whatsnew-pep-446.
