### PR TITLE
Allow easier customization of the testing cluster port range, closes #133

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ Features
   - Some low-level logging previously at the ``logging.INFO`` level is
     now logged at the ``logging.DEBUG`` level.
 
+- Issue #133: Introduce a new environment variable `ZOOKEEPER_PORT_OFFSET`
+  for the testing support, to run the testing cluster on a different range.
+
 Bug Handling
 ************
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -19,6 +19,10 @@ If your Java setup is complex, you may also override our classpath mechanism
 completely by specifying an environment variable called `ZOOKEEPER_CLASSPATH`.
 If provided, it will be used unmodified as the Java classpath for Zookeeper.
 
+You can specify an optional `ZOOKEEPER_PORT_OFFSET` environment variable to
+influence the ports the cluster is using. By default the offset is 20000 and
+a cluster with three members will use ports 20000, 20010 and 20020.
+
 
 Kazoo Test Harness
 ==================

--- a/kazoo/testing/harness.py
+++ b/kazoo/testing/harness.py
@@ -24,12 +24,18 @@ def get_global_cluster():
     if CLUSTER is None:
         ZK_HOME = os.environ.get("ZOOKEEPER_PATH")
         ZK_CLASSPATH = os.environ.get("ZOOKEEPER_CLASSPATH")
+        ZK_PORT_OFFSET = int(os.environ.get("ZOOKEEPER_PORT_OFFSET", 20000))
+
         assert ZK_HOME or ZK_CLASSPATH, (
             "either ZOOKEEPER_PATH or ZOOKEEPER_CLASSPATH environment variable "
             "must be defined.\n"
             "For deb package installations this is /usr/share/java")
 
-        CLUSTER = ZookeeperCluster(ZK_HOME, classpath=ZK_CLASSPATH)
+        CLUSTER = ZookeeperCluster(
+            install_path=ZK_HOME,
+            classpath=ZK_CLASSPATH,
+            port_offset=ZK_PORT_OFFSET,
+        )
         atexit.register(lambda cluster: cluster.terminate(), CLUSTER)
     return CLUSTER
 


### PR DESCRIPTION
This makes it easier to run multiple independent test suites on the same machine at the same time.
