### PR TITLE
Inform the client instance of the returned protocol version

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -294,6 +294,7 @@ class KazooClient(object):
         self._reset_watchers()
         self._reset_session()
         self.last_zxid = 0
+        self._protocol_version = None
 
     def _reset_watchers(self):
         self._child_watchers = defaultdict(set)

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -593,6 +593,7 @@ class ConnectionHandler(object):
 
         # Load return values
         client._session_id = connect_result.session_id
+        client._protocol_version = connect_result.protocol_version
         negotiated_session_timeout = connect_result.time_out
         connect_timeout = negotiated_session_timeout / len(client.hosts)
         read_timeout = negotiated_session_timeout * 2.0 / 3.0


### PR DESCRIPTION
As per Connect#deserialize we get back the protocol version known by the server. With all current ZK implementations this will always be 0, though with https://issues.apache.org/jira/browse/ZOOKEEPER-1607 that might change (ditto with future protocol extensions).

So lets save the returned value in the client instance so it can be introspected. For now, a private instance var (i.e.: _protocol_version) should do. I guess later on we could make it public. Not adding tests since this is just copying around something that the ZK protocol has supported forever. 

Signed-off-by: Raul Gutierrez S rgs@itevenworks.net
