### PR TITLE
Import `unittest.mock` if available

### DIFF
--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -4,7 +4,11 @@ import time
 import uuid
 import unittest
 
-from mock import patch
+try:  # python>=3.3 has mock builtin
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
 from nose import SkipTest
 from nose.tools import eq_
 from nose.tools import raises

--- a/kazoo/tests/test_connection.py
+++ b/kazoo/tests/test_connection.py
@@ -9,7 +9,11 @@ import struct
 from nose import SkipTest
 from nose.tools import eq_
 from nose.tools import raises
-import mock
+
+try:  # python>=3.3 has mock builtin
+    from unittest import mock
+except ImportError:
+    import mock
 
 from kazoo.exceptions import ConnectionLoss
 from kazoo.protocol.serialization import (

--- a/kazoo/tests/test_threading_handler.py
+++ b/kazoo/tests/test_threading_handler.py
@@ -1,7 +1,11 @@
 import threading
 import unittest
 
-import mock
+try:  # python>=3.3 has mock builtin
+    from unittest import mock
+except ImportError:
+    import mock
+
 from nose.tools import assert_raises
 from nose.tools import eq_
 from nose.tools import raises


### PR DESCRIPTION
Python >= 3.3 has `mock` module builtin as `unittest.mock`. I think it's nice to use it if available
