### PR TITLE
Unregistering atexit handlers after stop Sequential*

### DIFF
--- a/kazoo/handlers/gevent.py
+++ b/kazoo/handlers/gevent.py
@@ -109,7 +109,8 @@ class SequentialGeventHandler(object):
             # Clear the queues
             self.callback_queue = Queue()  # pragma: nocover
 
-            atexit.unregister(self.stop)
+            if hasattr(atexit, "unregister"):
+                atexit.unregister(self.stop)
 
     def select(self, *args, **kwargs):
         return gevent.select.select(*args, **kwargs)

--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -243,7 +243,8 @@ class SequentialThreadingHandler(object):
             # Clear the queues
             self.callback_queue = self.queue_impl()
             self.completion_queue = self.queue_impl()
-            atexit.unregister(self.stop)
+            if hasattr(atexit, "unregister"):
+                atexit.unregister(self.stop)
 
     def select(self, *args, **kwargs):
         return select.select(*args, **kwargs)


### PR DESCRIPTION
When using disposable connections in my program increased memory consumption. 
Patch fixes this by removing the handlers from atexit.
