### PR TITLE
Move reconnect code into KazooTestHarness#force_reconnect

### DIFF
--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -1,4 +1,3 @@
-import socket
 import sys
 import threading
 import time
@@ -223,9 +222,7 @@ class TestConnection(KazooTestCase):
 
     def test_add_auth_on_reconnect(self):
         self.client.add_auth("digest", "jsmith:jsmith")
-        self.client._connection._socket.shutdown(socket.SHUT_RDWR)
-        while not self.client.connected:
-            time.sleep(0.1)
+        self.force_reconnect()
         self.assertTrue(("digest", "jsmith:jsmith") in self.client.auth_data)
 
     def test_session_expire(self):


### PR DESCRIPTION
I think this will be useful for other tests so move it to one of the base classes (i.e.: I am already using it for some branches I am preparing for read-only support and SetWatches support). 

Signed-off-by: Raul Gutierrez S rgs@itevenworks.net
