### PR TITLE
Add support for non-ephemeral leases in the semaphore recipie

### DIFF
--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -395,6 +395,18 @@ class Semaphore(object):
         self._session_expired = False
         self.ephemeral_lease = ephemeral_lease
 
+        # if its not ephemeral, make sure we didn't already grab it
+        if not self.ephemeral_lease:
+            for child in self.client.get_children(self.path):
+                try:
+                    data, stat = self.client.get(self.path + "/" + child)
+                    if identifier == data.decode('utf-8'):
+                        self.create_path = self.path + "/" + child
+                        self.is_acquired = True
+                        break
+                except NoNodeError:  # pragma: nocover
+                    pass
+
     def _ensure_path(self):
         result = self.client.ensure_path(self.path)
         self.assured_path = True

--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -397,15 +397,18 @@ class Semaphore(object):
 
         # if its not ephemeral, make sure we didn't already grab it
         if not self.ephemeral_lease:
-            for child in self.client.get_children(self.path):
-                try:
-                    data, stat = self.client.get(self.path + "/" + child)
-                    if identifier == data.decode('utf-8'):
-                        self.create_path = self.path + "/" + child
-                        self.is_acquired = True
-                        break
-                except NoNodeError:  # pragma: nocover
-                    pass
+            try:
+                for child in self.client.get_children(self.path):
+                    try:
+                        data, stat = self.client.get(self.path + "/" + child)
+                        if identifier == data.decode('utf-8'):
+                            self.create_path = self.path + "/" + child
+                            self.is_acquired = True
+                            break
+                    except NoNodeError:  # pragma: nocover
+                        pass
+            except NoNodeError:  # pragma: nocover
+                pass
 
     def _ensure_path(self):
         result = self.client.ensure_path(self.path)


### PR DESCRIPTION
This is useful when the task you are tring to limit concurrency (such as a deployment) when a failure should retain a lock.
