### PR TITLE
Rawlink a callback on transaction completion

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -1381,16 +1381,14 @@ class TransactionRequest(object):
 
         """
         def on_finish(result):
+            self.fired = False
             if not result.successful():
-                self.fired = False
                 return
             results = result.get()
             if any(isinstance(r, Exception) for r in results):
-                self.fired = False
                 return
             for result, op in zip(results, self.operations):
                 if isinstance(op, CheckVersion) and not result:
-                    self.fired = False
                     return
             self.committed = True
 

--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -1,6 +1,5 @@
 """Kazoo Zookeeper Client"""
 import inspect
-import itertools
 import logging
 import os
 import re
@@ -1389,9 +1388,6 @@ class TransactionRequest(object):
             results = result.get()
             if any(isinstance(r, KazooException) for r in results):
                 return
-            for r, op in itertools.izip(results, self.operations):
-                if isinstance(op, CheckVersion) and not r:
-                    return
             self.committed = True
 
         self._check_tx_state()

--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -1,5 +1,6 @@
 """Kazoo Zookeeper Client"""
 import inspect
+import itertools
 import logging
 import os
 import re
@@ -13,6 +14,7 @@ from kazoo.exceptions import (
     ConfigurationError,
     ConnectionClosedError,
     ConnectionLoss,
+    KazooException,
     NoNodeError,
     NodeExistsError,
     SessionExpiredError,
@@ -1385,10 +1387,10 @@ class TransactionRequest(object):
             if not result.successful():
                 return
             results = result.get()
-            if any(isinstance(r, Exception) for r in results):
+            if any(isinstance(r, KazooException) for r in results):
                 return
-            for result, op in zip(results, self.operations):
-                if isinstance(op, CheckVersion) and not result:
+            for r, op in itertools.izip(results, self.operations):
+                if isinstance(op, CheckVersion) and not r:
                     return
             self.committed = True
 


### PR DESCRIPTION
Instead of assuming that a transaction will
correctly complete before it actually does we
should be smarter about this and inspect the
result to determine if it actually did and only
if it did should we set the committed flag.

Fixes issue #222
