### PR TITLE
Add a checked commit transaction method

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -1403,7 +1403,7 @@ class TransactionRequest(object):
                   transaction.
 
         :raises:
-            :exc:`~kazoo.exceptions.KazooTransactionException` if transcation
+            :exc:`~kazoo.exceptions.KazooTransactionException` if transaction
             failures/issues happened during the committing process.
         """
         if not self.operations:

--- a/kazoo/exceptions.py
+++ b/kazoo/exceptions.py
@@ -7,6 +7,18 @@ class KazooException(Exception):
     inherit from"""
 
 
+class KazooTransactionException(KazooException):
+    """Raised when a transaction fails."""
+
+    def __init__(self, message, failures):
+        super(KazooTransactionException, self).__init__(message)
+        self._failures = failures
+
+    @property
+    def failures(self):
+        return self._failures
+
+
 class ZookeeperError(KazooException):
     """Base Zookeeper exception for errors originating from the
     Zookeeper server"""

--- a/kazoo/exceptions.py
+++ b/kazoo/exceptions.py
@@ -12,7 +12,7 @@ class KazooTransactionException(KazooException):
 
     def __init__(self, message, failures):
         super(KazooTransactionException, self).__init__(message)
-        self._failures = failures
+        self._failures = tuple(failures)
 
     @property
     def failures(self):


### PR DESCRIPTION
Instead of just having a commit method that leaves
the majority of the failure handling to the caller it
is nice to have a checked commit method that does most
of this work onbehalf of the caller (and throws an
exception when errors are detected).
