### PR TITLE
PatientChildrenWatch can lose watchers in case of connection suspend

### DIFF
--- a/kazoo/recipe/watchers.py
+++ b/kazoo/recipe/watchers.py
@@ -436,7 +436,8 @@ class PatientChildrenWatch(object):
     def _session_watcher(self, state):
         if state in (KazooState.LOST, KazooState.SUSPENDED):
             self._suspended = True
-        elif (state == KazooState.CONNECTED and
-              self._suspended and not self._stopped):
+        elif (state == KazooState.CONNECTED):
+            if (self._suspended and not self._stopped):
+                self.client.handler.spawn(self._check_children)
             self._suspended = False
-            self.client.handler.spawn(self._check_children)
+            


### PR DESCRIPTION
Hi.
If one zookeeper server suspends in cluster PatientChildrenWatch can lose watchers.
It lead to incorrect SetPartitioner work.
I've added session_watcher and checking that children same as before suspend.
It starts work after _inner_start finished
