### PR TITLE
Proper check if we hold the lock in locking queue

### DIFF
--- a/kazoo/recipe/queue.py
+++ b/kazoo/recipe/queue.py
@@ -254,7 +254,7 @@ class LockingQueue(BaseQueue):
         :returns: True if element was removed successfully, False otherwise.
         :rtype: bool
         """
-        if self.processing_element is not None and self.holds_lock:
+        if self.processing_element is not None and self.holds_lock():
             id_, value = self.processing_element
             with self.client.transaction() as transaction:
                 transaction.delete("{path}/{id}".format(


### PR DESCRIPTION
There's a misprint - instead of checking if we're holding the lock, we just checking method like `bool(self.holds_lock)`.