### PR TITLE
fix lose changes while last lock acquiring

### DIFF
--- a/kazoo/recipe/partitioner.py
+++ b/kazoo/recipe/partitioner.py
@@ -293,6 +293,9 @@ class SetPartitioner(object):
 
         # All locks acquired! Time for state transition, make sure
         # we didn't inadvertently get lost thus far
+        if self._children_updated or self.failed:
+            # check children after last lock
+            return self._abort_lock_acquisition()
         with self._state_change:
             if self.failed:  # pragma: nocover
                 return self.finish()
@@ -321,7 +324,7 @@ class SetPartitioner(object):
             # locks, abort
             self._fail_out()
             return
-        return self._child_watching(self._allocate_transition)
+        return self._child_watching(self._allocate_transition, async=True)
 
     def _child_watching(self, func=None, async=False):
         """Called when children are being watched to stabilize


### PR DESCRIPTION
SetPartitioner can lose data changes while waiting last lock.
Code to check this effect

``` python
#!/usr/bin/python
# coding: utf-8

import logging
from kazoo.client import KazooClient
import threading
import time



def partitioner_thread(num, client):
    if num == 1:
        time.sleep(10)
    partitioner_obj = client.SetPartitioner('/test_p', set=['1', '2', '3', '4'], identifier=str(num), time_boundary=3)
    while True:
        if partitioner_obj.failed:
            raise Exception("Lost or unable to acquire partition")
        elif partitioner_obj.release:
            partitioner_obj.release_set()
        elif partitioner_obj.acquired:
            active_partitions = list(p for p in partitioner_obj)
            print num, active_partitions
            time.sleep(3)
        elif partitioner_obj.allocating:
            partitioner_obj.wait_for_acquire()


def main():
    # logging.basicConfig(level=logging.DEBUG)
    logging.basicConfig()
    client = KazooClient('localhost:2181')
    client.start()
    client.ensure_path('test_p')
    l = client.Lock('/test_p/locks/3', identifier="main")
    l.acquire()
    for i in range(3):
        th = threading.Thread(target=partitioner_thread, args=(i, client))
        th.daemon = True
        th.start()
    time.sleep(20)
    l.release()
    print 'release'
    time.sleep(30)
    print 'stop'


if __name__ == "__main__":
    main()
    print 'exit'
```

Code `python return self._child_watching(self._allocate_transition, async=False)` in _abort_lock_acquisition leads to deadlock in test code
