### PR TITLE
Fixed endless loop problem in connection handler

### DIFF
--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -530,7 +530,7 @@ class ConnectionHandler(object):
                             raise ConnectionDropped(
                                 "outstanding heartbeat ping not received")
                         self._send_ping(connect_timeout)
-                    elif s[0] == self._socket:
+                    elif self._socket in s:
                         response = self._read_socket(read_timeout)
                         close_connection = response == CLOSE_RESPONSE
                     else:


### PR DESCRIPTION
The problem was that `select` could return more than one element, but only the first one was checked which could result in some situations in an endless loop.