### PR TITLE
Tweak some of the import(s)

### DIFF
--- a/kazoo/handlers/gevent.py
+++ b/kazoo/handlers/gevent.py
@@ -9,8 +9,6 @@ import gevent.queue
 import gevent.select
 import gevent.thread
 
-import kazoo.python2atexit as python2atexit
-
 from gevent.queue import Empty
 from gevent.queue import Queue
 from gevent import socket
@@ -20,6 +18,7 @@ except ImportError:
     from gevent.coros import Semaphore, RLock
 
 from kazoo.handlers import utils
+from kazoo import python2atexit
 
 _using_libevent = gevent.__version__.startswith('0.')
 

--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -9,6 +9,7 @@ except ImportError:  # pragma: nocover
 import errno
 import functools
 import os
+import select
 import socket
 import sys
 
@@ -160,13 +161,11 @@ def create_socket_pair(module, port=0):
             raise
 
     # Use select to wait for connect() to succeed.
-    import select
     timeout = 1
     readable = select.select([temp_srv_sock], [], [], timeout)[0]
     if temp_srv_sock not in readable:
         raise Exception('Client socket not connected in {} second(s)'.format(timeout))
     srv_sock, _ = temp_srv_sock.accept()
-
     return client_sock, srv_sock
 
 def create_tcp_socket(module):


### PR DESCRIPTION
Avoid late importing modules that we can just import at the
normal top of file time (late importing doesn't seem to add
any benefit and IMHO makes the code harder to understand).

Also order more of the imports to follow the standards where
they are typically ordered alphabetically (with stdlib modules
being before other modules and the library itself being last).