### PR TITLE
Use six for *some of* py3/py2 compat tweaks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Features
   in the openstack community). The ``requirements_eventlet.txt`` file lists
   the optional eventlet requirement(s) that needs to be satisfied when this
   new handler is used.
+- Use ``six`` to nicely handle the cross compatibility of kazoo with
+  python 2.x and 3.x (reducing/removing the need to have custom compatibility
+  code that replicates what six already provides).
 
 Bug Handling
 ************

--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -8,6 +8,8 @@ from collections import defaultdict, deque
 from functools import partial
 from os.path import split
 
+import six
+
 from kazoo.exceptions import (
     AuthFailedError,
     ConfigurationError,
@@ -62,10 +64,8 @@ from kazoo.recipe.queue import LockingQueue
 from kazoo.recipe.watchers import ChildrenWatch
 from kazoo.recipe.watchers import DataWatch
 
-try:  # pragma: nocover
-    basestring
-except NameError:  # pragma: nocover
-    basestring = str
+string_types = six.string_types
+bytes_types = (six.binary_type,)
 
 LOST_STATES = (KeeperState.EXPIRED_SESSION, KeeperState.AUTH_FAILED,
                KeeperState.CLOSED)
@@ -669,10 +669,10 @@ class KazooClient(object):
         :rtype: :class:`~kazoo.interfaces.IAsyncResult`
 
         """
-        if not isinstance(scheme, basestring):
-            raise TypeError("Invalid type for scheme")
-        if not isinstance(credential, basestring):
-            raise TypeError("Invalid type for credential")
+        if not isinstance(scheme, string_types):
+            raise TypeError("Invalid type for 'scheme' (string expected)")
+        if not isinstance(credential, string_types):
+            raise TypeError("Invalid type for 'credential' (string expected)")
 
         # we need this auth data to re-authenticate on reconnect
         self.auth_data.add((scheme, credential))
@@ -804,19 +804,20 @@ class KazooClient(object):
         if acl is None and self.default_acl:
             acl = self.default_acl
 
-        if not isinstance(path, basestring):
-            raise TypeError("path must be a string")
+        if not isinstance(path, string_types):
+            raise TypeError("Invalid type for 'path' (string expected)")
         if acl and (isinstance(acl, ACL) or
                     not isinstance(acl, (tuple, list))):
-            raise TypeError("acl must be a tuple/list of ACL's")
-        if value is not None and not isinstance(value, bytes):
-            raise TypeError("value must be a byte string")
+            raise TypeError("Invalid type for 'acl' (acl must be a tuple/list"
+                            " of ACL's")
+        if value is not None and not isinstance(value, bytes_types):
+            raise TypeError("Invalid type for 'value' (must be a byte string)")
         if not isinstance(ephemeral, bool):
-            raise TypeError("ephemeral must be a bool")
+            raise TypeError("Invalid type for 'ephemeral' (bool expected)")
         if not isinstance(sequence, bool):
-            raise TypeError("sequence must be a bool")
+            raise TypeError("Invalid type for 'sequence' (bool expected)")
         if not isinstance(makepath, bool):
-            raise TypeError("makepath must be a bool")
+            raise TypeError("Invalid type for 'makepath' (bool expected)")
 
         flags = 0
         if ephemeral:
@@ -946,10 +947,10 @@ class KazooClient(object):
         :rtype: :class:`~kazoo.interfaces.IAsyncResult`
 
         """
-        if not isinstance(path, basestring):
-            raise TypeError("path must be a string")
+        if not isinstance(path, string_types):
+            raise TypeError("Invalid type for 'path' (string expected)")
         if watch and not callable(watch):
-            raise TypeError("watch must be a callable")
+            raise TypeError("Invalid type for 'watch' (must be a callable)")
 
         async_result = self.handler.async_result()
         self._call(Exists(_prefix_root(self.chroot, path), watch),
@@ -988,10 +989,10 @@ class KazooClient(object):
         :rtype: :class:`~kazoo.interfaces.IAsyncResult`
 
         """
-        if not isinstance(path, basestring):
-            raise TypeError("path must be a string")
+        if not isinstance(path, string_types):
+            raise TypeError("Invalid type for 'path' (string expected)")
         if watch and not callable(watch):
-            raise TypeError("watch must be a callable")
+            raise TypeError("Invalid type for 'watch' (must be a callable)")
 
         async_result = self.handler.async_result()
         self._call(GetData(_prefix_root(self.chroot, path), watch),
@@ -1041,12 +1042,12 @@ class KazooClient(object):
         :rtype: :class:`~kazoo.interfaces.IAsyncResult`
 
         """
-        if not isinstance(path, basestring):
-            raise TypeError("path must be a string")
+        if not isinstance(path, string_types):
+            raise TypeError("Invalid type for 'path' (string expected)")
         if watch and not callable(watch):
-            raise TypeError("watch must be a callable")
+            raise TypeError("Invalid type for 'watch' (must be a callable)")
         if not isinstance(include_data, bool):
-            raise TypeError("include_data must be a bool")
+            raise TypeError("Invalid type for 'include_data' (bool expected)")
 
         async_result = self.handler.async_result()
         if include_data:
@@ -1083,8 +1084,8 @@ class KazooClient(object):
         :rtype: :class:`~kazoo.interfaces.IAsyncResult`
 
         """
-        if not isinstance(path, basestring):
-            raise TypeError("path must be a string")
+        if not isinstance(path, string_types):
+            raise TypeError("Invalid type for 'path' (string expected)")
 
         async_result = self.handler.async_result()
         self._call(GetACL(_prefix_root(self.chroot, path)), async_result)
@@ -1126,12 +1127,13 @@ class KazooClient(object):
         :rtype: :class:`~kazoo.interfaces.IAsyncResult`
 
         """
-        if not isinstance(path, basestring):
-            raise TypeError("path must be a string")
+        if not isinstance(path, string_types):
+            raise TypeError("Invalid type for 'path' (string expected)")
         if isinstance(acls, ACL) or not isinstance(acls, (tuple, list)):
-            raise TypeError("acl must be a tuple/list of ACL's")
+            raise TypeError("Invalid type for 'acl' (acl must be a tuple/list"
+                            " of ACL's")
         if not isinstance(version, int):
-            raise TypeError("version must be an int")
+            raise TypeError("Invalid type for 'version' (int expected)")
 
         async_result = self.handler.async_result()
         self._call(SetACL(_prefix_root(self.chroot, path), acls, version),
@@ -1180,12 +1182,12 @@ class KazooClient(object):
         :rtype: :class:`~kazoo.interfaces.IAsyncResult`
 
         """
-        if not isinstance(path, basestring):
-            raise TypeError("path must be a string")
-        if value is not None and not isinstance(value, bytes):
-            raise TypeError("value must be a byte string")
+        if not isinstance(path, string_types):
+            raise TypeError("Invalid type for 'path' (string expected)")
+        if value is not None and not isinstance(value, bytes_types):
+            raise TypeError("Invalid type for 'value' (must be a byte string)")
         if not isinstance(version, int):
-            raise TypeError("version must be an int")
+            raise TypeError("Invalid type for 'version' (int expected)")
 
         async_result = self.handler.async_result()
         self._call(SetData(_prefix_root(self.chroot, path), value, version),
@@ -1255,10 +1257,10 @@ class KazooClient(object):
         :rtype: :class:`~kazoo.interfaces.IAsyncResult`
 
         """
-        if not isinstance(path, basestring):
-            raise TypeError("path must be a string")
+        if not isinstance(path, string_types):
+            raise TypeError("Invalid type for 'path' (string expected)")
         if not isinstance(version, int):
-            raise TypeError("version must be an int")
+            raise TypeError("Invalid type for 'version' (int expected)")
         async_result = self.handler.async_result()
         self._call(Delete(_prefix_root(self.chroot, path), version),
                    async_result)
@@ -1322,16 +1324,17 @@ class TransactionRequest(object):
         if acl is None and self.client.default_acl:
             acl = self.client.default_acl
 
-        if not isinstance(path, basestring):
-            raise TypeError("path must be a string")
+        if not isinstance(path, string_types):
+            raise TypeError("Invalid type for 'path' (string expected)")
         if acl and not isinstance(acl, (tuple, list)):
-            raise TypeError("acl must be a tuple/list of ACL's")
-        if not isinstance(value, bytes):
-            raise TypeError("value must be a byte string")
+            raise TypeError("Invalid type for 'acl' (acl must be a tuple/list"
+                            " of ACL's")
+        if not isinstance(value, bytes_types):
+            raise TypeError("Invalid type for 'value' (must be a byte string)")
         if not isinstance(ephemeral, bool):
-            raise TypeError("ephemeral must be a bool")
+            raise TypeError("Invalid type for 'ephemeral' (bool expected)")
         if not isinstance(sequence, bool):
-            raise TypeError("sequence must be a bool")
+            raise TypeError("Invalid type for 'sequence' (bool expected)")
 
         flags = 0
         if ephemeral:
@@ -1350,10 +1353,10 @@ class TransactionRequest(object):
         `recursive`.
 
         """
-        if not isinstance(path, basestring):
-            raise TypeError("path must be a string")
+        if not isinstance(path, string_types):
+            raise TypeError("Invalid type for 'path' (string expected)")
         if not isinstance(version, int):
-            raise TypeError("version must be an int")
+            raise TypeError("Invalid type for 'version' (int expected)")
         self._add(Delete(_prefix_root(self.client.chroot, path), version))
 
     def set_data(self, path, value, version=-1):
@@ -1361,12 +1364,12 @@ class TransactionRequest(object):
         arguments as :meth:`KazooClient.set`.
 
         """
-        if not isinstance(path, basestring):
-            raise TypeError("path must be a string")
-        if not isinstance(value, bytes):
-            raise TypeError("value must be a byte string")
+        if not isinstance(path, string_types):
+            raise TypeError("Invalid type for 'path' (string expected)")
+        if not isinstance(value, bytes_types):
+            raise TypeError("Invalid type for 'value' (must be a byte string)")
         if not isinstance(version, int):
-            raise TypeError("version must be an int")
+            raise TypeError("Invalid type for 'version' (int expected)")
         self._add(SetData(_prefix_root(self.client.chroot, path), value,
                   version))
 
@@ -1377,10 +1380,10 @@ class TransactionRequest(object):
         does not match the specified version.
 
         """
-        if not isinstance(path, basestring):
-            raise TypeError("path must be a string")
+        if not isinstance(path, string_types):
+            raise TypeError("Invalid type for 'path' (string expected)")
         if not isinstance(version, int):
-            raise TypeError("version must be an int")
+            raise TypeError("Invalid type for 'version' (int expected)")
         self._add(CheckVersion(_prefix_root(self.client.chroot, path),
                   version))
 

--- a/kazoo/hosts.py
+++ b/kazoo/hosts.py
@@ -1,10 +1,6 @@
 import random
 
-try:
-    from urlparse import urlsplit
-except ImportError:
-    # try python3 then
-    from urllib.parse import urlsplit
+from six.moves import urllib_parse
 
 
 def collect_hosts(hosts, randomize=True):
@@ -16,7 +12,7 @@ def collect_hosts(hosts, randomize=True):
     for host_port in host_ports.split(","):
         # put all complexity of dealing with
         # IPv4 & IPv6 address:port on the urlsplit
-        res = urlsplit("xxx://" + host_port)
+        res = urllib_parse.urlsplit("xxx://" + host_port)
         host = res.hostname
         port = int(res.port) if res.port else 2181
         result.append((host.strip(), port))

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(here, 'CHANGES.rst')) as f:
 PYTHON3 = sys.version_info > (3, )
 PYPY = getattr(sys, 'pypy_version_info', False) and True or False
 
-install_requires = []
+install_requires = ['six']
 
 tests_require = install_requires + [
     'coverage',


### PR DESCRIPTION
Instead of doing customizations for py2/py3 just use
the six module (which is all this module does) to achieve
the same effect but in a more maintained and standard
way.

This uses the six module to do the following:

* Figure out what the best urllib parse is at.
* Figure out and use the byte/string types that six
  locates in the client (and adjust the type checks
  and exceptions raised to use it); also improves
  upon the type errors raised to hopefully be more
  meaningful.

There are still a few leftover but hopefully those can
be adjusted in the future (and in another patch series).