### PR TITLE
Fix a bunch of flake8 reported issues

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -1,7 +1,6 @@
 """Kazoo Zookeeper Client"""
 import inspect
 import logging
-import os
 import re
 import warnings
 from collections import defaultdict, deque

--- a/kazoo/handlers/eventlet.py
+++ b/kazoo/handlers/eventlet.py
@@ -24,7 +24,7 @@ _STOP = object()
 def _yield_before_after():
     # Yield to any other co-routines...
     #
-    # See http://eventlet.net/doc/modules/greenthread.html#eventlet.greenthread.sleep
+    # See: http://eventlet.net/doc/modules/greenthread.html
     # for how this zero sleep is really a cooperative yield to other potential
     # co-routines...
     eventlet.sleep(0)

--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -33,6 +33,7 @@ _STOP = object()
 
 log = logging.getLogger(__name__)
 
+
 class KazooTimeoutError(Exception):
     pass
 

--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -1,16 +1,13 @@
 """Kazoo handler helpers"""
 
+import errno
+import functools
+
 HAS_FNCTL = True
 try:
     import fcntl
 except ImportError:  # pragma: nocover
     HAS_FNCTL = False
-
-import errno
-import functools
-import os
-import socket
-import sys
 
 # sentinel objects
 _NONE = object()
@@ -120,6 +117,7 @@ class AsyncResult(object):
             if callback in self._callbacks:
                 self._callbacks.remove(callback)
 
+
 def _set_fd_cloexec(fd):
     flags = fcntl.fcntl(fd, fcntl.F_GETFD)
     fcntl.fcntl(fd, fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
@@ -130,6 +128,7 @@ def _set_default_tcpsock_options(module, sock):
     if HAS_FNCTL:
         _set_fd_cloexec(sock)
     return sock
+
 
 def create_socket_pair(module, port=0):
     """Create socket pair.
@@ -164,10 +163,12 @@ def create_socket_pair(module, port=0):
     timeout = 1
     readable = select.select([temp_srv_sock], [], [], timeout)[0]
     if temp_srv_sock not in readable:
-        raise Exception('Client socket not connected in {} second(s)'.format(timeout))
+        raise Exception('Client socket not connected in %s'
+                        ' second(s)' % (timeout))
     srv_sock, _ = temp_srv_sock.accept()
 
     return client_sock, srv_sock
+
 
 def create_tcp_socket(module):
     """Create a TCP socket with the CLOEXEC flag set.

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -1,6 +1,5 @@
 """Zookeeper Protocol Connection Handler"""
 import logging
-import os
 import random
 import select
 import socket
@@ -523,7 +522,8 @@ class ConnectionHandler(object):
                     # Watch for something to read or send
                     jitter_time = random.randint(0, 40) / 100.0
                     # Ensure our timeout is positive
-                    timeout = max([read_timeout / 2.0 - jitter_time, jitter_time])
+                    timeout = max([read_timeout / 2.0 - jitter_time,
+                                   jitter_time])
                     s = self.handler.select([self._socket, self._read_sock],
                                             [], [], timeout)[0]
 

--- a/kazoo/python2atexit.py
+++ b/kazoo/python2atexit.py
@@ -1,12 +1,16 @@
 """Uses the old atexit with added unregister for python 2.x
 and the new atexit for python 3.x
 """
-__all__ = ["register", "unregister"]
 
 import sys
 import atexit
 
+__all__ = ["register", "unregister"]
+
+
 _exithandlers = []
+
+
 def _run_exitfuncs():
     """run any registered exit functions
 
@@ -46,6 +50,7 @@ def register(func, *targs, **kargs):
         _exithandlers.append((func, targs, kargs))
     return func
 
+
 def unregister(func):
     """remove func from the list of functions that are registered
     doesn't do anything if func is not found
@@ -62,4 +67,3 @@ def unregister(func):
 if not hasattr(atexit, "unregister"):
     # Only in python 2.x
     atexit.register(_run_exitfuncs)
-

--- a/kazoo/testing/harness.py
+++ b/kazoo/testing/harness.py
@@ -3,7 +3,6 @@ import atexit
 import logging
 import os
 import uuid
-import threading
 import unittest
 
 from kazoo.client import KazooClient

--- a/kazoo/tests/test_connection.py
+++ b/kazoo/tests/test_connection.py
@@ -1,7 +1,5 @@
 from collections import namedtuple
-import sys
 import os
-import errno
 import threading
 import time
 import uuid
@@ -197,7 +195,7 @@ class TestConnectionHandler(KazooTestCase):
         client.stop()
         assert read_sock is not None
         assert write_sock is not None
-        
+
         read_sock.getsockname()
         write_sock.getsockname()
 
@@ -205,7 +203,7 @@ class TestConnectionHandler(KazooTestCase):
         client.close()
 
         # Todo check socket closing
-                   
+
         # start client back up. should get a new, valid socket
         client.start()
         read_sock = client._connection._read_sock
@@ -215,7 +213,6 @@ class TestConnectionHandler(KazooTestCase):
         assert write_sock is not None
         read_sock.getsockname()
         write_sock.getsockname()
-            
 
     def test_dirty_sock(self):
         client = self.client

--- a/kazoo/tests/test_interrupt.py
+++ b/kazoo/tests/test_interrupt.py
@@ -8,18 +8,20 @@ from kazoo.testing import KazooTestCase
 class KazooInterruptTests(KazooTestCase):
     def test_interrupted_systemcall(self):
         '''
-        Make sure interrupted system calls don't break the world, since we can't
-        control what all signals our connection thread will get
+        Make sure interrupted system calls don't break the world, since we
+        can't control what all signals our connection thread will get
         '''
         if 'linux' not in platform:
-            raise SkipTest('Unable to reproduce error case on non-linux platforms')
+            raise SkipTest('Unable to reproduce error case on'
+                           ' non-linux platforms')
 
         path = 'interrupt_test'
         value = b"1"
         self.client.create(path, value)
 
         # set the euid to the current process' euid.
-        # glibc sends SIGRT to all children, which will interrupt the system call
+        # glibc sends SIGRT to all children, which will interrupt the
+        # system call
         os.seteuid(os.geteuid())
 
         # basic sanity test that it worked alright


### PR DESCRIPTION
Fixes quite a few of the flake8 compliants that it was raising:

* Quite a few of unused module imports.
* Line lengths to long.
* Not enough newlines around functions.
* Lines with just whitespace.