### PR TITLE
fix attribute error when deleting node if self.node was not yet assigned

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,10 @@ Bug Handling
 
 - #261: Creating a sequential znode under / doesn't work.
 
+- #279: Fixed AttributeError 'Lock' object has no attribute 'node'. Caused
+        by the missing definition of self.node in __init__.
+
+
 Documentation
 *************
 

--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -72,6 +72,7 @@ class Lock(object):
         self.prefix = uuid.uuid4().hex + self._NODE_NAME
         self.create_path = self.path + "/" + self.prefix
 
+        self.node = None
         self.create_tried = False
         self.is_acquired = False
         self.assured_path = False
@@ -119,8 +120,9 @@ class Lock(object):
             self.cancelled = False
             raise
 
-        if not self.is_acquired:
+        if not self.is_acquired and self.node:
             self._delete_node(self.node)
+            self.node = None
 
         return self.is_acquired
 


### PR DESCRIPTION
The lock recipe can fail with attribute error when connection error happens before `self.node = node` is called.

Fixed by explicitly defining `self.node = None` in `__init___` and checking it before deleting the node when lock could not be acquired.
