### PR TITLE
Add retries to server_version() fetch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,9 @@ Bug Handling
 
 - #261: Creating a sequential znode under / doesn't work.
 
+- #274: Add server_version() retries (by default 4 attempts will be made) to
+  better handle flakey responses.
+
 Documentation
 *************
 

--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -14,6 +14,7 @@ from kazoo.exceptions import (
     ConfigurationError,
     ConnectionClosedError,
     ConnectionLoss,
+    KazooException,
     NoNodeError,
     NodeExistsError,
     SessionExpiredError,
@@ -678,7 +679,9 @@ class KazooClient(object):
             version = _try_fetch()
             if _is_valid(version):
                 return version
-        return None
+        raise KazooException("Unable to fetch useable server"
+                             " version after trying %s times"
+                             % (1 + max(0, retries)))
 
     def add_auth(self, scheme, credential):
         """Send credentials to server.

--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -68,7 +68,8 @@ bytes_types = (six.binary_type,)
 
 LOST_STATES = (KeeperState.EXPIRED_SESSION, KeeperState.AUTH_FAILED,
                KeeperState.CLOSED)
-ENVI_VERSION = re.compile('[\w\s:.]*=([\d\.]*).*', re.DOTALL)
+ENVI_VERSION = re.compile('([\d\.]*).*', re.DOTALL)
+ENVI_VERSION_KEY = 'zookeeper.version'
 log = logging.getLogger(__name__)
 
 
@@ -631,7 +632,7 @@ class KazooClient(object):
         sock.close()
         return result.decode('utf-8', 'replace')
 
-    def server_version(self):
+    def server_version(self, retries=3):
         """Get the version of the currently connected ZK server.
 
         :returns: The server version, for example (3, 4, 3).
@@ -640,9 +641,44 @@ class KazooClient(object):
         .. versionadded:: 0.5
 
         """
-        data = self.command(b'envi')
-        string = ENVI_VERSION.match(data).group(1)
-        return tuple([int(i) for i in string.split('.')])
+        def _try_fetch():
+            data = self.command(b'envi')
+            data_parsed = {}
+            for line in data.splitlines():
+                try:
+                    k, v = line.split("=", 1)
+                    k = k.strip()
+                    v = v.strip()
+                except ValueError:
+                    pass
+                else:
+                    if k:
+                        data_parsed[k] = v
+            version = data_parsed.get(ENVI_VERSION_KEY, '')
+            version_digits = ENVI_VERSION.match(version).group(1)
+            try:
+                return tuple([int(d) for d in version_digits.split('.')])
+            except ValueError:
+                return None
+
+        def _is_valid(version):
+            # All zookeeper versions should have at least major.minor
+            # version numbers; if we get one that doesn't it is likely not
+            # correct and was truncated...
+            if version and len(version) > 1:
+                return True
+            return False
+
+        # Try 1 + retries amount of times to get a version that we know
+        # will likely be acceptable...
+        version = _try_fetch()
+        if _is_valid(version):
+            return version
+        for _i in range(0, retries):
+            version = _try_fetch()
+            if _is_valid(version):
+                return version
+        return None
 
     def add_auth(self, scheme, credential):
         """Send credentials to server.

--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -675,7 +675,7 @@ class KazooClient(object):
         version = _try_fetch()
         if _is_valid(version):
             return version
-        for _i in range(0, retries):
+        for _i in six.moves.range(0, retries):
             version = _try_fetch()
             if _is_valid(version):
                 return version


### PR DESCRIPTION
Due to the apparent flakiness of the four-letter commands
we need to add a set of retries to the fetching of the
server version to handle getting partial or truncated values
back from it.

This adds a default of 4 tries (1 + 3 retries) to the server
version code so that if a partial value is returned (or no
server version at all) that the code will try again, if none
can be fetched in 4 tries; then none is returned to signify
this failure.

Fixes issue #274