### PR TITLE
Support SASL/GSSAPI authentication

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -36,6 +36,7 @@ from kazoo.protocol.serialization import (
     GetACL,
     SetACL,
     GetData,
+    SASLAuth,
     SetData,
     Sync,
     Transaction
@@ -598,9 +599,14 @@ class KazooClient(object):
         """
         if not isinstance(scheme, basestring):
             raise TypeError("Invalid type for scheme")
-        if not isinstance(credential, basestring):
-            raise TypeError("Invalid type for credential")
-        self._call(Auth(0, scheme, credential), None)
+        if scheme.upper() == 'GSSAPI':
+            if credential is not None:
+                raise TypeError("Invalid type for credential")
+            self._call(SASLAuth(self._connection._initialize_sasl()), None)
+        else:
+            if not isinstance(credential, basestring):
+                raise TypeError("Invalid type for credential")
+            self._call(Auth(0, scheme, credential), None)
         return True
 
     def unchroot(self, path):

--- a/kazoo/protocol/serialization.py
+++ b/kazoo/protocol/serialization.py
@@ -359,6 +359,15 @@ class Auth(namedtuple('Auth', 'auth_type scheme auth')):
         return (int_struct.pack(self.auth_type) + write_string(self.scheme) +
                 write_string(self.auth))
 
+class SASLAuth(namedtuple('SASLAuth', 'token')):
+    type = 102
+
+    def serialize(self):
+        if self.token is None:
+            # Empty message
+            return int_struct.pack(0)
+        return write_buffer(self.token)
+
 
 class Watch(namedtuple('Watch', 'type state path')):
     @classmethod

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ PYPY = getattr(sys, 'pypy_version_info', False) and True or False
 
 install_requires = [
     'zope.interface >= 3.8.0',  # has zope.interface.registry
+    'PyGSSAPI >= 1.0.0',        # for SASL/GSSAPI authentication support
 ]
 
 tests_require = install_requires + [


### PR DESCRIPTION
To trigger SASL/GSSAPI authentication, add an auth_data tuple of `("gssapi", None)` to the `KazooClient`. It uses the users current Kerberos credential cache to authenticate.

This was developed against 1.3.1, and so I fully expect it to *not* merge against the current HEAD of kazoo.

Furthermore it was developed against an older version of PyGSSAPI which included a bug. I fixed that bug in my own copy of PyGSSAPI, but when I went to submit the fix upstream, PyGSSAPI had been significantly modified and it was unbuildable at the time.

I'm only submitting this PR to serve as a reference for #130 and #284.