### PR TITLE
Use the helper python2atexit for atexit routines

### DIFF
--- a/kazoo/handlers/eventlet.py
+++ b/kazoo/handlers/eventlet.py
@@ -1,9 +1,10 @@
 """A eventlet based handler."""
 from __future__ import absolute_import
 
-import atexit
 import contextlib
 import logging
+
+import kazoo.python2atexit as python2atexit
 
 import eventlet
 from eventlet.green import select as green_select
@@ -127,7 +128,7 @@ class SequentialEventletHandler(object):
             w = eventlet.spawn(self._process_callback_queue)
             self._workers.append((w, self.callback_queue))
             self._started = True
-            atexit.register(self.stop)
+            python2atexit.register(self.stop)
 
     def stop(self):
         while self._workers:
@@ -135,8 +136,7 @@ class SequentialEventletHandler(object):
             q.put(_STOP)
             w.wait()
         self._started = False
-        if hasattr(atexit, "unregister"):
-            atexit.unregister(self.stop)
+        python2atexit.unregister(self.stop)
 
     def socket(self, *args, **kwargs):
         return utils.create_tcp_socket(green_socket)


### PR DESCRIPTION
Use the right ``atexit`` routines (that work better in py2/py3).