### PR TITLE
Use the spawn method when creating thread handler workers

### DIFF
--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -89,7 +89,7 @@ class SequentialThreadingHandler(object):
         self._workers = []
 
     def _create_thread_worker(self, queue):
-        def thread_worker():  # pragma: nocover
+        def _thread_worker():  # pragma: nocover
             while True:
                 try:
                     func = queue.get()
@@ -103,13 +103,7 @@ class SequentialThreadingHandler(object):
                         queue.task_done()
                 except self.queue_empty:
                     continue
-        t = threading.Thread(target=thread_worker)
-
-        # Even though these should be joined, it's possible stop might
-        # not issue in time so we set them to daemon to let the program
-        # exit anyways
-        t.daemon = True
-        t.start()
+        t = self.spawn(_thread_worker)
         return t
 
     def start(self):


### PR DESCRIPTION
Instead of creating daemon threads in two places, both
using the same code, just have the `_create_thread_worker`
method call into the spawn method to delegate to it to create
a daemon thread.