### PR TITLE
Have the lock reentrancy behave like threading.lock

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,7 @@ Bug Handling
   would remove the underlying lock. This would leave the X - 1 other `acquire`
   statements unprotected (and no longer holding there expected lock). To fix
   this the comment about that lock recipe being re-entrant has been removed
-  and multiple acquires will now raise a ``RuntimeError`` when attempted.
+  and multiple acquires will now raise a block when attempted.
 
 - #78: Kazoo now uses socketpairs instead of pipes making it compatible with
   Windows.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,7 @@ Bug Handling
   would remove the underlying lock. This would leave the X - 1 other `acquire`
   statements unprotected (and no longer holding there expected lock). To fix
   this the comment about that lock recipe being re-entrant has been removed
-  and multiple acquires will now raise a block when attempted.
+  and multiple acquires will now block when attempted.
 
 - #78: Kazoo now uses socketpairs instead of pipes making it compatible with
   Windows.

--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -116,6 +116,7 @@ class Lock(object):
             got_it = self._lock.acquire(False)
             if not got_it:
                 raise ForceRetryError()
+            return True
 
         retry = self._retry.copy()
         retry.deadline = timeout
@@ -128,7 +129,7 @@ class Lock(object):
         if not locked:
             # Lock acquire doesn't take a timeout, so simulate it...
             try:
-                retry(_acquire_lock)
+                locked = retry(_acquire_lock)
             except RetryFailedError:
                 return False
         already_acquired = self.is_acquired

--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -139,7 +139,7 @@ class Lock(object):
                 gotten = retry(self._inner_acquire,
                                blocking=blocking, timeout=timeout)
             except RetryFailedError:
-                if not already_acquired
+                if not already_acquired:
                     self._best_effort_cleanup()
             except KazooException:
                 # if we did ultimately fail, attempt to clean up

--- a/kazoo/tests/test_lock.py
+++ b/kazoo/tests/test_lock.py
@@ -1,6 +1,7 @@
-import uuid
-import time
+import collections
 import threading
+import time
+import uuid
 
 from nose.tools import eq_, ok_
 
@@ -8,6 +9,28 @@ from kazoo.exceptions import CancelledError
 from kazoo.exceptions import LockTimeout
 from kazoo.testing import KazooTestCase
 from kazoo.tests import util as test_util
+
+
+class SleepBarrier(object):
+    """A crappy spinning barrier."""
+
+    def __init__(self, wait_for):
+        self._wait_for = wait_for
+        self._arrived = collections.deque()
+
+    def __enter__(self):
+        self._arrived.append(threading.current_thread())
+        return self
+
+    def __exit__(self, type, value, traceback):
+        try:
+            self._arrived.remove(threading.current_thread())
+        except ValueError:
+            pass
+
+    def wait(self):
+        while len(self._arrived) < self._wait_for:
+            time.sleep(0.001)
 
 
 class KazooLockTests(KazooTestCase):
@@ -251,26 +274,39 @@ class KazooLockTests(KazooTestCase):
         self.assertFalse(lock1.is_acquired)
 
     def test_lock_many_threads(self):
-        lock1 = self.client.Lock(self.lockpath, "one")
-        acquires = []
+        lock = self.client.Lock(self.lockpath, "one")
+        acquires = collections.deque()
+        chain = collections.deque()
+        thread_count = 20
+        differences = collections.deque()
+        barrier = SleepBarrier(thread_count)
 
         def _acquire():
-            with lock1:
-                time.sleep(0.01)
-                acquires.append(True)
+            # Wait until all threads are ready to go...
+            with barrier as b:
+                b.wait()
+                with lock:
+                    # Ensure that no two threads enter here and cause the
+                    # count to differ by more than one, do this by recording
+                    # the count that was captured and examining it post run.
+                    starting_count = len(acquires)
+                    acquires.append(1)
+                    time.sleep(0.01)
+                    end_count = len(acquires)
+                    differences.append(end_count - starting_count)
 
         threads = []
-        for _i in range(0, 10):
+        for _i in range(0, thread_count):
             t = self.make_thread(target=_acquire)
-            t.start()
             threads.append(t)
+            t.start()
 
         while threads:
             t = threads.pop()
             t.join()
 
-        self.assertEqual(10, len(acquires))
-        self.assertTrue(all(acquires))
+        self.assertEqual(thread_count, len(acquires))
+        self.assertEqual([1] * thread_count, list(differences))
 
     def test_lock_reacquire(self):
         lock = self.client.Lock(self.lockpath, "one")


### PR DESCRIPTION
Instead of having it raise a runtime error have the calling
thread block until the lock has been released (typically
by some other thread). This more closely matches the existing
and (assumingly) expected behavior of locks.