### PR TITLE
Don't crash when the hosts strings is bogus

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,8 @@ Bug Handling
 - #283: Fixed a race condition in SetPartitioner when party changes during
   handling of lock acquisition.
 
+- #303: don't crash on random input as the hosts string.
+
 Documentation
 *************
 

--- a/kazoo/hosts.py
+++ b/kazoo/hosts.py
@@ -14,6 +14,8 @@ def collect_hosts(hosts, randomize=True):
         # IPv4 & IPv6 address:port on the urlsplit
         res = urllib_parse.urlsplit("xxx://" + host_port)
         host = res.hostname
+        if host is None:
+            raise ValueError("bad hostname")
         port = int(res.port) if res.port else 2181
         result.append((host.strip(), port))
 

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -104,6 +104,11 @@ class TestClientConstructor(unittest.TestCase):
         timeout = client.handler.timeout_exception
         self.assertRaises(timeout, client.start, 0.1)
 
+    def test_another_invalid_hostname(self):
+        self.assertRaises(
+            ValueError,
+            self._makeOne, hosts='/nosuchhost/a')
+
     def test_retry_options_dict(self):
         from kazoo.retry import KazooRetry
         client = self._makeOne(command_retry=dict(max_tries=99),


### PR DESCRIPTION
Here's an example of crashing with a bad hosts string:

```
In [1]: from kazoo.client import KazooClient

In [2]: k = KazooClient("/nosuchhost/a")
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-25a91e9f619d> in <module>()
----> 1 k = KazooClient("/nosuchhost/a")

/usr/lib/python2.7/site-packages/kazoo-2.0.1dev-py2.7.egg/kazoo/client.pyc in __init__(self, hosts, timeout, client_id, handler, default_acl, auth_data, read_only, randomize_hosts, connection_retry, command_retry, logger, **kwargs)
    181         self.hosts = None
    182         self.chroot = None
--> 183         self.set_hosts(hosts)
    184 
    185         # Curator like simplified state tracking, and listeners for

/usr/lib/python2.7/site-packages/kazoo-2.0.1dev-py2.7.egg/kazoo/client.pyc in set_hosts(self, hosts, randomize_hosts)
    365             randomize_hosts = self.randomize_hosts
    366 
--> 367         self.hosts, chroot = collect_hosts(hosts, randomize_hosts)
    368 
    369         if chroot:

/usr/lib/python2.7/site-packages/kazoo-2.0.1dev-py2.7.egg/kazoo/hosts.pyc in collect_hosts(hosts, randomize)
     20         host = res.hostname
     21         port = int(res.port) if res.port else 2181
---> 22         result.append((host.strip(), port))
     23 
     24     if randomize:

AttributeError: 'NoneType' object has no attribute 'strip'
```

Fixes #303 

Signed-off-by: Raul Gutierrez S <rgs@itevenworks.net>