### PR TITLE
[RFC] Support SetWatches and watch restoration

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -453,7 +453,8 @@ class KazooClient(object):
             self._live.clear()
             self._notify_pending(state)
             self._make_state_change(KazooState.SUSPENDED)
-            self._reset_watchers()
+            if state != KeeperState.CONNECTING:
+                self._reset_watchers()
 
     def _notify_pending(self, state):
         """Used to clear a pending response queue and request queue

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -26,6 +26,7 @@ from kazoo.protocol.serialization import (
     Ping,
     PingInstance,
     ReplyHeader,
+    SetWatches,
     Transaction,
     Watch,
     int_struct
@@ -59,6 +60,7 @@ CHILD_EVENT = 4
 WATCH_XID = -1
 PING_XID = -2
 AUTH_XID = -4
+SET_WATCHES_XID = -8
 
 CLOSE_RESPONSE = Close.type
 
@@ -406,6 +408,8 @@ class ConnectionHandler(object):
                 async_object.set(True)
         elif header.xid == WATCH_XID:
             self._read_watch_event(buffer, offset)
+        elif header.xid == SET_WATCHES_XID:
+            self.logger.log(BLATHER, 'Received SetWatches reply')
         else:
             self.logger.log(BLATHER, 'Reading for header %r', header)
 
@@ -438,6 +442,8 @@ class ConnectionHandler(object):
         # Special case for auth packets
         if request.type == Auth.type:
             xid = AUTH_XID
+        elif request.type == SetWatches.type:
+            xid = SET_WATCHES_XID
         else:
             self._xid += 1
             xid = self._xid
@@ -588,6 +594,10 @@ class ConnectionHandler(object):
                           client._session_id or 0, client._session_passwd,
                           client.read_only)
 
+        # save the client's last_zxid before it gets overwritten by the server's.
+        # we'll need this to reset watches via SetWatches further below.
+        last_zxid = client.last_zxid
+
         connect_result, zxid = self._invoke(
             client._session_timeout / 1000.0, connect)
 
@@ -626,4 +636,15 @@ class ConnectionHandler(object):
             zxid = self._invoke(connect_timeout / 1000.0, ap, xid=AUTH_XID)
             if zxid:
                 client.last_zxid = zxid
+
+        # TODO: separate exist from data watches
+        if client._data_watchers or client._child_watchers.keys():
+            sw = SetWatches(last_zxid,
+                            client._data_watchers.keys(),
+                            client._data_watchers.keys(),
+                            client._child_watchers.keys())
+            zxid = self._invoke(connect_timeout / 1000.0, sw, xid=SET_WATCHES_XID)
+            if zxid:
+                client.last_zxid = zxid
+
         return read_timeout, connect_timeout

--- a/kazoo/protocol/serialization.py
+++ b/kazoo/protocol/serialization.py
@@ -14,6 +14,7 @@ int_int_struct = struct.Struct('!ii')
 int_int_long_struct = struct.Struct('!iiq')
 
 int_long_int_long_struct = struct.Struct('!iqiq')
+long_struct = struct.Struct('!q')
 multiheader_struct = struct.Struct('!iBi')
 reply_header_struct = struct.Struct('!iqi')
 stat_struct = struct.Struct('!qqqqiiiqiiq')
@@ -51,6 +52,14 @@ def write_string(bytes):
     else:
         utf8_str = bytes.encode('utf-8')
         return int_struct.pack(len(utf8_str)) + utf8_str
+
+
+def write_string_vector(v):
+    b = bytearray()
+    b.extend(int_struct.pack(len(v)))
+    for s in v:
+        b.extend(write_string(s))
+    return b
 
 
 def write_buffer(bytes):
@@ -358,6 +367,20 @@ class Auth(namedtuple('Auth', 'auth_type scheme auth')):
     def serialize(self):
         return (int_struct.pack(self.auth_type) + write_string(self.scheme) +
                 write_string(self.auth))
+
+
+class SetWatches(
+        namedtuple('SetWatches',
+                   'relativeZxid, dataWatches, existWatches, childWatches')):
+    type = 101
+
+    def serialize(self):
+        b = bytearray()
+        b.extend(long_struct.pack(self.relativeZxid))
+        b.extend(write_string_vector(self.dataWatches))
+        b.extend(write_string_vector(self.existWatches))
+        b.extend(write_string_vector(self.childWatches))
+        return b
 
 
 class Watch(namedtuple('Watch', 'type state path')):


### PR DESCRIPTION
Basic plumbing to support resetting watches upon recovering a session (as done by the Java implementation).

Given this breaks the current behaviour, it should be made optional. I'll circle back with that added in. Comments welcomed! 

Fixes #218 

Signed-off-by: Raul Gutierrez S rgs@itevenworks.net
