### PR TITLE
Implement read-write (shared) lock from ZooKeeper recipe.

### DIFF
--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -217,7 +217,14 @@ class Lock(object):
     def _get_sorted_children(self):
         children = self.client.get_children(self.path)
 
-        # can't just sort directly: the node names are prefixed by uuids
+        # Node names are prefixed by uuids: strip the prefix first, which may
+        # be one of multiple values in case of a read-write lock, and return
+        # only the sequence number (as a string since it is padded and will sort
+        # correctly anyway).
+        #
+        # In some cases, the lock path may contain nodes with other prefixes
+        # (eg. in case of a lease), just sort them last ('~' sorts after all
+        # ASCII digits).
         def _seq(c):
             for name in ["__lock__", "__rlock__"]:
                 idx = c.find(name)

--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -43,11 +43,18 @@ class Lock(object):
     Note: This lock is not *re-entrant*. Repeated calls after already
     acquired will raise a ``RuntimeError``.
 
+    This is an exclusive lock. For a read/write lock, see :method:`WLock` and
+    :method:`RLock`.
+
     """
 
-    def __init__(self, client, path, identifier=None, node_name=None,
+    def __init__(self, client, path, identifier=None, node_name="__lock__",
                  exclude_names=None):
         """Create a Kazoo lock.
+
+        node_name and exclude_names are typically only used internally to
+        implement read/write locks. They should be left unset for exclusive
+        locks.
 
         :param client: A :class:`~kazoo.client.KazooClient` instance.
         :param path: The lock path to use.
@@ -71,8 +78,6 @@ class Lock(object):
 
         self.wake_event = client.handler.event_object()
 
-        if node_name is None:
-            node_name = "__lock__"
         self.node_name = node_name
 
         if exclude_names is None:
@@ -299,7 +304,7 @@ def WLock(*args, **kwargs):
     .. code-block:: python
 
         zk = KazooClient()
-        lock = WLock("/lockpath", "my-identifier")
+        lock = WLock(zk, "/lockpath", "my-identifier")
         with lock:  # blocks waiting for any outstanding readers and writers
             # do something with the lock
 
@@ -324,7 +329,7 @@ def RLock(*args, **kwargs):
     .. code-block:: python
 
         zk = KazooClient()
-        lock = RLock("/lockpath", "my-identifier")
+        lock = RLock(zk, "/lockpath", "my-identifier")
         with lock:  # blocks waiting for any outstanding writers
             # do something with the lock
 

--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -218,7 +218,8 @@ class Lock(object):
                 idx = c.find(name)
                 if idx != -1:
                     return c[idx + len(name):]
-            raise ValueError("Unknown node type: %s" % c)
+            # Sort unknown node names eg. "lease_holder" last.
+            return '~'
         children.sort(key=_seq)
         return children
 

--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -217,7 +217,7 @@ class Lock(object):
     def _get_sorted_children(self):
         children = self.client.get_children(self.path)
 
-        # Node names are prefixed by uuids: strip the prefix first, which may
+        # Node names are prefixed by a type: strip the prefix first, which may
         # be one of multiple values in case of a read-write lock, and return
         # only the sequence number (as a string since it is padded and will sort
         # correctly anyway).


### PR DESCRIPTION
Reference: http://zookeeper.apache.org/doc/trunk/recipes.html#Shared+Locks

This is a writer-preference shared lock.

Most of the lock protocol is the same as for an exclusive lock, except that it needs to be parameterized on:
1) Node name - lock "kind" - a write lock (**lock**) or read lock (**rlock**).
2) Which node names block which other node names (read locks block only writers, writers block both).
3) Finding the predecessor node according to the rule in #2.

These changes are integrated to the main Lock class. The changes are backward compatible with existing users of Lock. Users should normally never pass the Lock node_name and exclude_names kwargs directly, they should use WLock and RLock.
