### PR TITLE
Re-set the ping_outstanding event before connecting

### DIFF
--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -517,6 +517,7 @@ class ConnectionHandler(object):
             connect_timeout = connect_timeout / 1000.0
             retry.reset()
             self._xid = 0
+            self.ping_outstanding.clear()
             with self._socket_error_handling():
                 while not close_connection:
                     # Watch for something to read or send


### PR DESCRIPTION
If the client disconnects with the ping_outstanding event set, when it
reconnects the first timeout will cause a "dropped" heartbeat, and make
the library reconnect yet again.