### PR TITLE
Use the compat layer for atexit functionality

### DIFF
--- a/kazoo/testing/harness.py
+++ b/kazoo/testing/harness.py
@@ -1,9 +1,11 @@
 """Kazoo testing harnesses"""
-import atexit
+
 import logging
 import os
 import uuid
 import unittest
+
+from kazoo import python2atexit as atexit
 
 from kazoo.client import KazooClient
 from kazoo.exceptions import NotEmptyError


### PR DESCRIPTION
Instead of using ``atexit``, use the compat. layer that makes sure the py2.x versions of atexit function properly.