### PR TITLE
Ensure zookeeper clients are safely torn down after each test

### DIFF
--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -471,7 +471,7 @@ class Semaphore(object):
                 else:
                     # If not blocking, register another watch that will trigger
                     # self._get_lease() as soon as the children change again.
-                    self.client.get_children(self.path, self._get_lease)
+                    # self.client.get_children(self.path, self._get_lease)
                     return False
         finally:
             lock.release()
@@ -528,7 +528,6 @@ class Semaphore(object):
     def _inner_release(self):
         if not self.is_acquired:
             return False
-
         try:
             self.client.delete(self.create_path)
         except NoNodeError:  # pragma: nocover

--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -469,9 +469,6 @@ class Semaphore(object):
                             "Failed to acquire semaphore on %s "
                             "after %s seconds" % (self.path, timeout))
                 else:
-                    # If not blocking, register another watch that will trigger
-                    # self._get_lease() as soon as the children change again.
-                    # self.client.get_children(self.path, self._get_lease)
                     return False
         finally:
             lock.release()

--- a/kazoo/testing/common.py
+++ b/kazoo/testing/common.py
@@ -149,22 +149,26 @@ log4j.appender.ROLLINGFILE.Threshold=DEBUG
 log4j.appender.ROLLINGFILE.File=""" + to_java_compatible_path(  # NOQA
                 self.working_path + os.sep + "zookeeper.log\n"))
 
-        self.process = subprocess.Popen(
-            args=["java",
-                  "-cp", self.classpath,
+        args = [
+            "java",
+            "-cp", self.classpath,
 
-                  # "-Dlog4j.debug",
-                  "-Dreadonlymode.enabled=true",
-                  "-Dzookeeper.log.dir=%s" % log_path,
-                  "-Dzookeeper.root.logger=INFO,CONSOLE",
-                  "-Dlog4j.configuration=file:%s" % log4j_path,
+            # "-Dlog4j.debug",
+            "-Dreadonlymode.enabled=true",
+            "-Dzookeeper.log.dir=%s" % log_path,
+            "-Dzookeeper.root.logger=INFO,CONSOLE",
+            "-Dlog4j.configuration=file:%s" % log4j_path,
 
-                  # OS X: Prevent java from appearing in menu bar, process dock
-                  # and from activation of the main workspace on run.
-                  "-Djava.awt.headless=true",
+            # OS X: Prevent java from appearing in menu bar, process dock
+            # and from activation of the main workspace on run.
+            "-Djava.awt.headless=true",
 
-                  "org.apache.zookeeper.server.quorum.QuorumPeerMain",
-                  config_path])
+            "org.apache.zookeeper.server.quorum.QuorumPeerMain",
+            config_path,
+        ]
+        self.process = subprocess.Popen(args=args)
+        log.info("Started zookeeper process %s using args %s",
+                 self.process.pid, args)
         self._running = True
 
     @property

--- a/kazoo/testing/common.py
+++ b/kazoo/testing/common.py
@@ -231,7 +231,7 @@ log4j.appender.ROLLINGFILE.File=""" + to_java_compatible_path(  # NOQA
         self.process.terminate()
         self.process.wait()
         if self.process.returncode != 0:
-            log.warn("Zookeeper process %s failed top terminate with"
+            log.warn("Zookeeper process %s failed to terminate with"
                      " non-zero return code (it terminated with %s return"
                      " code instead)", self.process.pid,
                      self.process.returncode)

--- a/kazoo/testing/common.py
+++ b/kazoo/testing/common.py
@@ -21,6 +21,7 @@
 
 
 import code
+import logging
 import os
 import os.path
 import shutil
@@ -32,6 +33,9 @@ import traceback
 from itertools import chain
 from collections import namedtuple
 from glob import glob
+
+
+log = logging.getLogger(__name__)
 
 
 def debug(sig, frame):
@@ -226,6 +230,11 @@ log4j.appender.ROLLINGFILE.File=""" + to_java_compatible_path(  # NOQA
             return
         self.process.terminate()
         self.process.wait()
+        if self.process.returncode != 0:
+            log.warn("Zookeeper process %s failed top terminate with"
+                     " non-zero return code (it terminated with %s return"
+                     " code instead)", self.process.pid,
+                     self.process.returncode)
         self._running = False
 
     def destroy(self):

--- a/kazoo/testing/harness.py
+++ b/kazoo/testing/harness.py
@@ -79,14 +79,13 @@ class KazooTestHarness(unittest.TestCase):
         return ",".join([s.address for s in self.cluster])
 
     def _get_nonchroot_client(self):
-        return KazooClient(self.servers)
+        c = KazooClient(self.servers)
+        self._clients.append(c)
+        return c
 
     def _get_client(self, **kwargs):
         c = KazooClient(self.hosts, **kwargs)
-        try:
-            self._clients.append(c)
-        except AttributeError:
-            self._client = [c]
+        self._clients.append(c)
         return c
 
     def lose_connection(self, event_factory):
@@ -101,13 +100,11 @@ class KazooTestHarness(unittest.TestCase):
         """Create a ZK cluster and chrooted :class:`KazooClient`
 
         The cluster will only be created on the first invocation and won't be
-        fully torn down until exit.
+        fully torn down until teardown_zookeeper is called.
         """
-        if not self.cluster[0].running:
-            self.cluster.start()
+        self.cluster.start()
         namespace = "/kazootests" + uuid.uuid4().hex
         self.hosts = self.servers + namespace
-
         if 'timeout' not in client_options:
             client_options['timeout'] = 0.8
         self.client = self._get_client(**client_options)
@@ -115,35 +112,13 @@ class KazooTestHarness(unittest.TestCase):
         self.client.ensure_path("/")
 
     def teardown_zookeeper(self):
-        """Clean up any ZNodes created during the test
-        """
-        if not self.cluster[0].running:
-            self.cluster.start()
-
-        tries = 0
-        if self.client and self.client.connected:
-            while tries < 3:
-                try:
-                    self.client.retry(self.client.delete, '/', recursive=True)
-                    break
-                except NotEmptyError:
-                    pass
-                tries += 1
-            self.client.stop()
-            self.client.close()
-            del self.client
-        else:
-            client = self._get_client()
-            client.start()
-            client.retry(client.delete, '/', recursive=True)
-            client.stop()
-            client.close()
-            del client
-
-        for client in self._clients:
-            client.stop()
-            del client
-        self._clients = None
+        """Reset and cleanup the zookeeper cluster that was started."""
+        while self._clients:
+            c = self._clients.pop()
+            c.stop()
+            c.close()
+        self.client = None
+        self.cluster.reset()
 
     def __break_connection(self, break_event, expected_state, event_factory):
         """Break ZooKeeper connection using the specified event."""

--- a/kazoo/tests/test_lock.py
+++ b/kazoo/tests/test_lock.py
@@ -536,12 +536,9 @@ class TestSemaphore(KazooTestCase):
 
         def sema_one():
             started.set()
-            try:
-                with expire_semaphore:
-                    event.set()
-                    event2.wait()
-            except KazooException:
-                pass
+            with expire_semaphore:
+                event.set()
+                event2.wait()
 
         thread1 = self.make_thread(target=sema_one, args=())
         thread1.start()

--- a/kazoo/tests/test_lock.py
+++ b/kazoo/tests/test_lock.py
@@ -407,7 +407,7 @@ class TestSemaphore(KazooTestCase):
         self.threads_made = []
 
     def tearDown(self):
-        super(KazooLockTests, self).tearDown()
+        super(TestSemaphore, self).tearDown()
         while self.threads_made:
             t = self.threads_made.pop()
             t.join()

--- a/kazoo/tests/test_lock.py
+++ b/kazoo/tests/test_lock.py
@@ -38,6 +38,16 @@ class SleepBarrier(object):
 class KazooLockTests(KazooTestCase):
     thread_count = 20
 
+    def setUp(self):
+        super(KazooLockTests, self).setUp()
+        self.threads_made = []
+
+    def tearDown(self):
+        super(KazooLockTests, self).tearDown()
+        while self.threads_made:
+            t = self.threads_made.pop()
+            t.join()
+
     @staticmethod
     def make_condition():
         return threading.Condition()
@@ -46,9 +56,11 @@ class KazooLockTests(KazooTestCase):
     def make_event():
         return threading.Event()
 
-    @staticmethod
-    def make_thread(*args, **kwargs):
-        return threading.Thread(*args, **kwargs)
+    def make_thread(self, *args, **kwargs):
+        t = threading.Thread(*args, **kwargs)
+        t.daemon = True
+        self.threads_made.append(t)
+        return t
 
     @staticmethod
     def make_wait():

--- a/kazoo/tests/test_lock.py
+++ b/kazoo/tests/test_lock.py
@@ -402,6 +402,16 @@ class KazooLockTests(KazooTestCase):
 
 class TestSemaphore(KazooTestCase):
 
+    def __init__(self, *args, **kw):
+        super(TestSemaphore, self).__init__(*args, **kw)
+        self.threads_made = []
+
+    def tearDown(self):
+        super(KazooLockTests, self).tearDown()
+        while self.threads_made:
+            t = self.threads_made.pop()
+            t.join()
+
     @staticmethod
     def make_condition():
         return threading.Condition()
@@ -410,9 +420,11 @@ class TestSemaphore(KazooTestCase):
     def make_event():
         return threading.Event()
 
-    @staticmethod
-    def make_thread(*args, **kwargs):
-        return threading.Thread(*args, **kwargs)
+    def make_thread(self, *args, **kwargs):
+        t = threading.Thread(*args, **kwargs)
+        t.daemon = True
+        self.threads_made.append(t)
+        return t
 
     def setUp(self):
         super(TestSemaphore, self).setUp()

--- a/kazoo/tests/test_lock.py
+++ b/kazoo/tests/test_lock.py
@@ -38,8 +38,8 @@ class SleepBarrier(object):
 class KazooLockTests(KazooTestCase):
     thread_count = 20
 
-    def setUp(self):
-        super(KazooLockTests, self).setUp()
+    def __init__(self, *args, **kw):
+        super(KazooLockTests, self).__init__(*args, **kw)
         self.threads_made = []
 
     def tearDown(self):


### PR DESCRIPTION
Add robustness to the teardown process:

- Avoids trying to cleanup chrooted roots (its not always safe to); the client who created it should clean it up themselves (since they are most able to).
- Tries to cleanly stop and close each client created (and tracks all clients that were created).
- Adds checks + logs to make sure that on each stop that is called that the zookeeper process has exited cleanly with a zero error code.
- Adds logs to show what processes are started.
- Removes having a watcher on children on a non-blocking semaphore (that doesn't seem to make any sense).
- Handles the non-blocking sempahore case better (it should also use a non-blocking lock, to avoid locking up).