### PR TITLE
Do cleanup in a more more robust manner

### DIFF
--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -522,7 +522,6 @@ class Semaphore(object):
     def _inner_release(self):
         if not self.is_acquired:
             return False
-
         try:
             self.client.delete(self.create_path)
         except NoNodeError:  # pragma: nocover


### PR DESCRIPTION
- Adds checks to make sure that on each stop that
  is called that the zookeeper process has exited cleanly with
  a zero error code (and log if this doesn't happen)

- Log the started programs

- Track all created clients (and stop them on teardown)

- Track threads made in lock/sempahore tests and clean them up