### PR TITLE
Ensure tox is always installed into the virtualenv.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ ifneq ($(TRAVIS), true)
 	$(INSTALL) -U -r requirements_sphinx.txt
 endif
 	$(INSTALL) -U -r requirements.txt
+	$(INSTALL) -U tox
 	$(PYTHON) setup.py develop
 	$(INSTALL) kazoo[test]
 
@@ -45,7 +46,7 @@ clean:
 	rm -rf $(BUILD_DIRS)
 
 test:
-	tox -e$(TOX_VENV)
+	$(BIN)/tox -e$(TOX_VENV)
 
 html:
 	cd docs && \


### PR DESCRIPTION
I tried to run make && make test and it failed for me, as I don't have tox installed in my global environment. This makes sure we install tox into the kazoo virtualenv and use it from there via bin/tox.