### PR TITLE
Make use of the new travis-ci caching mechanism.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ man/
 parts/
 share/
 site-packages/
+zookeeper/
 .coverage
 .idea
 .pip_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - zookeeper
+
 language: python
 python:
     - "2.7"
@@ -38,9 +45,6 @@ matrix:
 
 notifications:
   email: false
-
-before_install:
-    - sudo apt-get install libevent-dev
 
 install:
     - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 sudo: false
 
+addons:
+  apt:
+    packages:
+    - libevent-dev
+
 cache:
   directories:
     - $HOME/.cache/pip

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ BIN = $(HERE)/bin
 PYTHON = $(BIN)/python
 PIP_DOWNLOAD_CACHE ?= $(HERE)/.pip_cache
 INSTALL = $(BIN)/pip install
-INSTALL += --download-cache $(PIP_DOWNLOAD_CACHE)
+ifneq ($(TRAVIS), true)
+    INSTALL += --download-cache $(PIP_DOWNLOAD_CACHE)
+endif
 TOX_VENV ?= py27
 BUILD_DIRS = bin build include lib lib64 man share
 

--- a/ensure-zookeeper-env.sh
+++ b/ensure-zookeeper-env.sh
@@ -3,9 +3,9 @@
 set -e
 
 HERE=`pwd`
-ZOO_BASE_DIR="$HERE/bin/"
+ZOO_BASE_DIR="$HERE/zookeeper"
 ZOOKEEPER_VERSION=${ZOOKEEPER_VERSION:-3.4.6}
-ZOOKEEPER_PATH="$ZOO_BASE_DIR/zookeeper-$ZOOKEEPER_VERSION"
+ZOOKEEPER_PATH="$ZOO_BASE_DIR/$ZOOKEEPER_VERSION"
 ZOO_MIRROR_URL="http://apache.osuosl.org/"
 
 
@@ -13,6 +13,7 @@ function download_zookeeper(){
     mkdir -p $ZOO_BASE_DIR
     cd $ZOO_BASE_DIR
     curl --silent -C - $ZOO_MIRROR_URL/zookeeper/zookeeper-$ZOOKEEPER_VERSION/zookeeper-$ZOOKEEPER_VERSION.tar.gz | tar -zx
+    mv zookeeper-$ZOOKEEPER_VERSION $ZOOKEEPER_VERSION
     chmod a+x $ZOOKEEPER_PATH/bin/zkServer.sh
 }
 


### PR DESCRIPTION
This moves the Zookeeper install from `bin/zookeeper-3.4.6` to `zookeeper/3.4.6` to make it easier to cache it.

In the new sudo-less environment you can't use `sudo apt-get` anymore. This might result in failing to installed gevent 0.13.8, gevent 1.0.x includes a copy of libev inside the tar.gz, so it should build fine.

First test to see if the caches get populated...