### PR TITLE
Fix up tox envs and their usage in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,23 +6,31 @@ matrix:
         - python: "2.7"
     include:
         - python: "2.6"
-          env: GEVENT_VERSION=0.13.8 ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py26
+          env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py26
         - python: "2.6"
-          env: GEVENT_VERSION=0.13.8 ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py26
+          env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py26
         - python: "2.6"
-          env: GEVENT_VERSION=1.0.1 ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py26
+          env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py26-gevent-0.13.8
         - python: "2.6"
-          env: GEVENT_VERSION=1.0.1 ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py26
+          env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py26-gevent-0.13.8
+        - python: "2.6"
+          env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py26-gevent-1.0.1
+        - python: "2.6"
+          env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py26-gevent-1.0.1
         - python: "2.7"
-          env: GEVENT_VERSION=0.13.8 ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py27
+          env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py27
         - python: "2.7"
-          env: GEVENT_VERSION=0.13.8 ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py27
+          env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py27
         - python: "2.7"
-          env: GEVENT_VERSION=1.0.1 ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py27
+          env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py27-gevent-0.13.8
         - python: "2.7"
-          env: GEVENT_VERSION=1.0.1 ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py27
+          env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py27-gevent-0.13.8
         - python: "2.7"
-          env: GEVENT_VERSION=1.0.1 ZOOKEEPER_VERSION=3.5.0-alpha TOX_VENV=py27
+          env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py27-gevent-1.0.1
+        - python: "2.7"
+          env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py27-gevent-1.0.1
+        - python: "2.7"
+          env: ZOOKEEPER_VERSION=3.5.0-alpha TOX_VENV=py27-gevent-1.0.1
         - python: "3.3"
           env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py33
         - python: "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,27 +10,27 @@ matrix:
         - python: "2.6"
           env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py26
         - python: "2.6"
-          env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py26-gevent-0.13.8
+          env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py26-gevent
         - python: "2.6"
-          env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py26-gevent-0.13.8
+          env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py26-gevent
         - python: "2.6"
-          env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py26-gevent-1.0.1
+          env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py26-eventlet
         - python: "2.6"
-          env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py26-gevent-1.0.1
+          env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py26-eventlet
         - python: "2.7"
           env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py27
         - python: "2.7"
           env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py27
         - python: "2.7"
-          env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py27-gevent-0.13.8
+          env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py27-gevent
         - python: "2.7"
-          env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py27-gevent-0.13.8
+          env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py27-gevent
         - python: "2.7"
-          env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py27-gevent-1.0.1
+          env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py27-eventlet
         - python: "2.7"
-          env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py27-gevent-1.0.1
+          env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py27-eventlet
         - python: "2.7"
-          env: ZOOKEEPER_VERSION=3.5.0-alpha TOX_VENV=py27-gevent-1.0.1
+          env: ZOOKEEPER_VERSION=3.5.0-alpha TOX_VENV=py27-gevent
         - python: "3.3"
           env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py33
         - python: "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         - python: "2.7"
           env: ZOOKEEPER_VERSION=3.4.6 TOX_VENV=py27-eventlet
         - python: "2.7"
-          env: ZOOKEEPER_VERSION=3.5.0-alpha TOX_VENV=py27-gevent
+          env: ZOOKEEPER_VERSION=3.5.0-alpha TOX_VENV=py27
         - python: "3.3"
           env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py33
         - python: "3.3"

--- a/requirements_eventlet.txt
+++ b/requirements_eventlet.txt
@@ -1,1 +1,1 @@
-eventlet>=0.17.4
+eventlet>=0.16.1

--- a/requirements_eventlet.txt
+++ b/requirements_eventlet.txt
@@ -1,1 +1,1 @@
-eventlet>=0.16.1
+eventlet>=0.17.1

--- a/requirements_eventlet.txt
+++ b/requirements_eventlet.txt
@@ -1,1 +1,1 @@
-eventlet>=0.16.1
+eventlet>=0.17.4

--- a/requirements_gevent.txt
+++ b/requirements_gevent.txt
@@ -1,1 +1,1 @@
-greenlet==0.4.3
+gevent

--- a/requirements_gevent.txt
+++ b/requirements_gevent.txt
@@ -1,1 +1,1 @@
-gevent
+gevent>=1.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@ minversion = 1.6
 skipsdist = True
 envlist = pep8,
     py26,
-    py26-gevent-0.13.8,
-    py26-gevent-1.0.1,
+    py26-gevent,
+    py26-eventlet,
     py27,
-    py27-gevent-0.13.8,
-    py27-gevent-1.0.1,
+    py27-gevent,
+    py27-eventlet,
     py33,
     py34,
     pypy
@@ -23,39 +23,21 @@ deps = -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_sphinx.txt
 commands = {toxinidir}/ensure-zookeeper-env.sh nosetests {posargs: -d -v --with-coverage kazoo.tests}
 
-[testenv:py27]
+[testenv:py27-gevent]
 deps = {[testenv]deps}
     -r{toxinidir}/requirements_gevent.txt
+
+[testenv:py27-eventlet]
+deps = {[testenv]deps}
     -r{toxinidir}/requirements_eventlet.txt
-    gevent
 
-[testenv:py27-gevent-0.13.8]
+[testenv:py26-gevent]
 deps = {[testenv]deps}
     -r{toxinidir}/requirements_gevent.txt
-    gevent==0.13.8
 
-[testenv:py27-gevent-1.0.1]
+[testenv:py26-eventlet]
 deps = {[testenv]deps}
-    -r{toxinidir}/requirements_gevent.txt
-    gevent==1.0.1
-
-[testenv:py26]
-deps = {[testenv]deps}
-    -r{toxinidir}/requirements_gevent.txt
     -r{toxinidir}/requirements_eventlet.txt
-    gevent
-
-[testenv:py26-gevent-0.13.8]
-deps = {[testenv]deps}
-    -r{toxinidir}/requirements_gevent.txt
-    -r{toxinidir}/requirements_eventlet.txt
-    gevent==0.13.8
-
-[testenv:py26-gevent-1.0.1]
-deps = {[testenv]deps}
-    -r{toxinidir}/requirements_gevent.txt
-    -r{toxinidir}/requirements_eventlet.txt
-    gevent==1.0.1
 
 [flake8]
 builtins = _

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,11 @@ minversion = 1.6
 skipsdist = True
 envlist = pep8,
     py26,
+    py26-gevent-0.13.8,
+    py26-gevent-1.0.1,
     py27,
+    py27-gevent-0.13.8,
+    py27-gevent-1.0.1,
     py33,
     py34,
     pypy
@@ -19,15 +23,47 @@ deps = -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_sphinx.txt
 commands = {toxinidir}/ensure-zookeeper-env.sh nosetests {posargs: -d -v --with-coverage kazoo.tests}
 
+[testenv:py34]
+deps = {[testenv]deps}
+    -r{toxinidir}/requirements_eventlet.txt
+
+[testenv:py33]
+deps = {[testenv]deps}
+    -r{toxinidir}/requirements_eventlet.txt
+
 [testenv:py27]
 deps = {[testenv]deps}
     -r{toxinidir}/requirements_gevent.txt
     -r{toxinidir}/requirements_eventlet.txt
+    gevent
+
+[testenv:py27-gevent-0.13.8]
+deps = {[testenv]deps}
+    -r{toxinidir}/requirements_gevent.txt
+    gevent==0.13.8
+
+[testenv:py27-gevent-1.0.1]
+deps = {[testenv]deps}
+    -r{toxinidir}/requirements_gevent.txt
+    gevent==1.0.1
 
 [testenv:py26]
 deps = {[testenv]deps}
     -r{toxinidir}/requirements_gevent.txt
     -r{toxinidir}/requirements_eventlet.txt
+    gevent
+
+[testenv:py26-gevent-0.13.8]
+deps = {[testenv]deps}
+    -r{toxinidir}/requirements_gevent.txt
+    -r{toxinidir}/requirements_eventlet.txt
+    gevent==0.13.8
+
+[testenv:py26-gevent-1.0.1]
+deps = {[testenv]deps}
+    -r{toxinidir}/requirements_gevent.txt
+    -r{toxinidir}/requirements_eventlet.txt
+    gevent==1.0.1
 
 [flake8]
 builtins = _

--- a/tox.ini
+++ b/tox.ini
@@ -23,14 +23,6 @@ deps = -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_sphinx.txt
 commands = {toxinidir}/ensure-zookeeper-env.sh nosetests {posargs: -d -v --with-coverage kazoo.tests}
 
-[testenv:py34]
-deps = {[testenv]deps}
-    -r{toxinidir}/requirements_eventlet.txt
-
-[testenv:py33]
-deps = {[testenv]deps}
-    -r{toxinidir}/requirements_eventlet.txt
-
 [testenv:py27]
 deps = {[testenv]deps}
     -r{toxinidir}/requirements_gevent.txt


### PR DESCRIPTION
Ensure that we have specific virtualenvs listed in tox that install the
desired gevent and eventlet versions and ensure that the
``.travis.yml`` file references them for usage.

This also adds gevent (with no version restriction) to the py27, py26
builds (with postfix ``-gevent``) and also adds eventlet specific virtualenvs
(with postfix ``-eventlet``) for making sure that eventlet and gevent
continues to work.

Fixes issue #328