### PR TITLE
On demand bind for recipe classes to the client class

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -48,6 +48,7 @@ from kazoo.protocol.states import KeeperState
 from kazoo.retry import KazooRetry
 from kazoo.security import ACL
 from kazoo.security import OPEN_ACL_UNSAFE
+from kazoo.utils import bind
 
 # convenience API
 from kazoo.recipe.barrier import Barrier
@@ -93,6 +94,7 @@ _RETRY_COMPAT_MAPPING = dict(
 )
 
 
+@bind.on_demand
 class KazooClient(object):
     """An Apache Zookeeper Python client supporting alternate callback
     handlers and high-level functionality.
@@ -103,6 +105,23 @@ class KazooClient(object):
     :class:`~kazoo.protocol.states.WatchedEvent` instance.
 
     """
+
+    Barrier = bind(Barrier)
+    Counter = bind(Counter)
+    DoubleBarrier = bind(DoubleBarrier)
+    ChildrenWatch = bind(ChildrenWatch)
+    DataWatch = bind(DataWatch)
+    Election = bind(Election)
+    NonBlockingLease = bind(NonBlockingLease)
+    MultiNonBlockingLease = bind(MultiNonBlockingLease)
+    Lock = bind(Lock)
+    Party = bind(Party)
+    Queue = bind(Queue)
+    LockingQueue = bind(LockingQueue)
+    SetPartitioner = bind(SetPartitioner)
+    Semaphore = bind(Semaphore)
+    ShallowParty = bind(ShallowParty)
+
     def __init__(self, hosts='127.0.0.1:2181',
                  timeout=10.0, client_id=None, handler=None,
                  default_acl=None, auth_data=None, read_only=None,
@@ -271,22 +290,6 @@ class KazooClient(object):
         def _retry(*args, **kwargs):
             return self._retry.copy()(*args, **kwargs)
         self.retry = _retry
-
-        self.Barrier = partial(Barrier, self)
-        self.Counter = partial(Counter, self)
-        self.DoubleBarrier = partial(DoubleBarrier, self)
-        self.ChildrenWatch = partial(ChildrenWatch, self)
-        self.DataWatch = partial(DataWatch, self)
-        self.Election = partial(Election, self)
-        self.NonBlockingLease = partial(NonBlockingLease, self)
-        self.MultiNonBlockingLease = partial(MultiNonBlockingLease, self)
-        self.Lock = partial(Lock, self)
-        self.Party = partial(Party, self)
-        self.Queue = partial(Queue, self)
-        self.LockingQueue = partial(LockingQueue, self)
-        self.SetPartitioner = partial(SetPartitioner, self)
-        self.Semaphore = partial(Semaphore, self)
-        self.ShallowParty = partial(ShallowParty, self)
 
         # If we got any unhandled keywords, complain like Python would
         if kwargs:

--- a/kazoo/utils.py
+++ b/kazoo/utils.py
@@ -1,0 +1,19 @@
+from types import MethodType
+
+
+def _on_demand(cls):
+    def rebind(dct):
+        for name, obj in dct.items():
+            try:
+                wrap, obj = obj
+                if wrap is MethodType:
+                    setattr(cls, name, wrap(obj, None, cls))
+            except (TypeError, ValueError):
+                pass
+    rebind(cls.__dict__)
+    return cls
+
+
+def bind(callable):
+    return MethodType, callable
+bind.on_demand = _on_demand


### PR DESCRIPTION
Bind all recipes at the client class only once at the class creation time.
Implemented over class decorator, because it's more portable than metaclass.
Also this type of bind saves access to the **doc** attribute of original classes,
what is useful for example with IPython.
