### PR TITLE
Bump version up to 2.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,11 @@
 Changelog
 =========
 
-2.2 (unreleased)
-----------------
+2.2
+---
+
+Documentation
+*************
 
 Features
 ********
@@ -12,21 +15,10 @@ Features
 Bug Handling
 ************
 
-Documentation
-*************
-
-2.1.1
------
-
-Features
-********
-
-Bug Handling
-************
-
 - #315: multiple acquires of a kazoo lock using the lock recipe would
   block when using `acquire` even when non-blocking is specified (only
   when the lock was/has been already acquired).
+- #318: At exit register takes *args and **kwargs not args and kargs
 
 Documentation
 *************

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-__version__ = '2.1.1'
+__version__ = '2.2'
 
 import os
 import sys


### PR DESCRIPTION
Version 2.1.1 was never released (due to **repeated** travis build errors)
so we can remove it from being a version number and go directly
to 2.2 (and collapse the CHANGES.rst to account for that).