### PR TITLE
Use 'isinstance' instead of 'type'

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -213,22 +213,19 @@ class KazooClient(object):
 
         self.retry = self._conn_retry = None
 
-        if type(connection_retry) is dict:
+        if isinstance(connection_retry, dict):
             self._conn_retry = KazooRetry(**connection_retry)
-        elif type(connection_retry) is KazooRetry:
+        elif isinstance(connection_retry, KazooRetry):
             self._conn_retry = connection_retry
-
-        if type(command_retry) is dict:
+        if isinstance(command_retry, dict):
             self.retry = KazooRetry(**command_retry)
-        elif type(command_retry) is KazooRetry:
+        elif isinstance(command_retry, KazooRetry):
             self.retry = command_retry
-
-        if type(self._conn_retry) is KazooRetry:
+        if isinstance(self._conn_retry, KazooRetry):
             if self.handler.sleep_func != self._conn_retry.sleep_func:
                 raise ConfigurationError("Retry handler and event handler "
                                          " must use the same sleep func")
-
-        if type(self.retry) is KazooRetry:
+        if isinstance(self.retry, KazooRetry):
             if self.handler.sleep_func != self.retry.sleep_func:
                 raise ConfigurationError(
                     "Command retry handler and event handler "

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -116,8 +116,8 @@ class TestClientConstructor(unittest.TestCase):
         from kazoo.retry import KazooRetry
         client = self._makeOne(command_retry=dict(max_tries=99),
                                connection_retry=dict(delay=99))
-        self.assertTrue(type(client._conn_retry) is KazooRetry)
-        self.assertTrue(type(client._retry) is KazooRetry)
+        self.assertIsInstance(client._conn_retry, KazooRetry)
+        self.assertIsInstance(client._retry, KazooRetry)
         eq_(client._retry.max_tries, 99)
         eq_(client._conn_retry.delay, 99)
 

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -38,6 +38,18 @@ else:  # pragma: nocover
     def u(s):
         return unicode(s, "unicode_escape")
 
+if sys.version_info[0:2] == (2, 6):
+    # TODO(harlowja): fix this soon, using unittest2 or other...
+    class TestCase(unittest.TestCase):
+        def assertIsInstance(self, obj, cls, msg=None):
+            # Ripped/taken from python 3.4 and adjusted...
+            if not isinstance(obj, cls):
+                if not msg:
+                    msg = '%r is not an instance of %r' % (obj, cls)
+                self.fail(msg)
+else:
+    TestCase = unittest.TestCase
+
 
 class TestClientTransitions(KazooTestCase):
     @staticmethod
@@ -70,7 +82,7 @@ class TestClientTransitions(KazooTestCase):
         eq_(states, req_states)
 
 
-class TestClientConstructor(unittest.TestCase):
+class TestClientConstructor(TestCase):
 
     def _makeOne(self, *args, **kw):
         from kazoo.client import KazooClient
@@ -1101,7 +1113,7 @@ class TestClientTransactions(KazooTestCase):
         eq_(self.client.get('/smith')[0], b'32')
 
 
-class TestCallbacks(unittest.TestCase):
+class TestCallbacks(TestCase):
     def test_session_callback_states(self):
         from kazoo.protocol.states import KazooState, KeeperState
         from kazoo.client import KazooClient


### PR DESCRIPTION
It doesn't seem recommended to do `type(X) is Y` when isinstance does this in a more proper manner.
