### PR TITLE
Use testtools for better unittest testcase compatability

### DIFF
--- a/kazoo/testing/harness.py
+++ b/kazoo/testing/harness.py
@@ -3,7 +3,8 @@
 import logging
 import os
 import uuid
-import unittest
+
+import testtools
 
 from kazoo import python2atexit as atexit
 
@@ -41,7 +42,7 @@ def get_global_cluster():
     return CLUSTER
 
 
-class KazooTestHarness(unittest.TestCase):
+class KazooTestHarness(testtools.TestCase):
     """Harness for testing code that uses Kazoo
 
     This object can be used directly or as a mixin. It supports starting

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ tests_require = install_requires + [
     'mock',
     'nose',
     'flake8',
+    'testtools',
 ]
 
 if not (PYTHON3 or PYPY):

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,1 @@
+testtools

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,1 +1,5 @@
 testtools
+flake8
+mock
+coverage
+nose

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ install_command = pip install {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
 deps = -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_sphinx.txt
+    -r{toxinidir}/test_requirements.txt
 commands = {toxinidir}/ensure-zookeeper-env.sh nosetests {posargs: -d -v --with-coverage kazoo.tests}
 
 [testenv:py27-gevent]


### PR DESCRIPTION
Testtools provides compat. methods that make missing unittest
methods on older versions of python exist, so that they can
be used on those older versions.
