### PR TITLE
Fix examples in recipes

### DIFF
--- a/kazoo/recipe/counter.py
+++ b/kazoo/recipe/counter.py
@@ -29,6 +29,7 @@ class Counter(object):
     .. code-block:: python
 
         zk = KazooClient()
+        zk.start()
         counter = zk.Counter("/int")
         counter += 2
         counter -= 1

--- a/kazoo/recipe/election.py
+++ b/kazoo/recipe/election.py
@@ -13,6 +13,7 @@ class Election(object):
     Example usage with a :class:`~kazoo.client.KazooClient` instance::
 
         zk = KazooClient()
+        zk.start()
         election = zk.Election("/electionpath", "my-identifier")
 
         # blocks until the election is won, then calls

--- a/kazoo/recipe/lease.py
+++ b/kazoo/recipe/lease.py
@@ -29,6 +29,7 @@ class NonBlockingLease(object):
     Example usage: with a :class:`~kazoo.client.KazooClient` instance::
 
         zk = KazooClient()
+        zk.start()
         # Hold lease over an hour in order to keep job on same machine, with failover if it dies.
         lease = zk.NonBlockingLease("/db_leases/hourly_cleanup", datetime.timedelta(minutes = 70),
           identifier = "DB hourly cleanup on " + socket.gethostname())

--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -60,6 +60,7 @@ class Lock(object):
     .. code-block:: python
 
         zk = KazooClient()
+        zk.start()
         lock = zk.Lock("/lockpath", "my-identifier")
         with lock:  # blocks waiting for lock acquisition
             # do something with the lock

--- a/kazoo/recipe/partitioner.py
+++ b/kazoo/recipe/partitioner.py
@@ -80,6 +80,7 @@ class SetPartitioner(object):
 
         from kazoo.client import KazooClient
         client = KazooClient()
+        client.start()
 
         qp = client.SetPartitioner(
             path='/work_queues', set=('queue-1', 'queue-2', 'queue-3'))


### PR DESCRIPTION
Fix the recipe examples, so they actually work by connecting
to ZooKeeper. Without start() they just hang and can't be killed.