### PR TITLE
Make lock._inner_acquire robust to paths without leading slashes.

### DIFF
--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -143,7 +143,7 @@ class Lock(object):
             node = self.client.create(self.create_path, self.data,
                                       ephemeral=True, sequence=True)
             # strip off path to node
-            node = node[len(self.path) + 1:]
+            node = node.rpartition("/")[-1]
 
         self.node = node
 

--- a/kazoo/tests/test_lock.py
+++ b/kazoo/tests/test_lock.py
@@ -278,6 +278,16 @@ class KazooLockTests(KazooTestCase):
             t.join()
             client2.stop()
 
+    def test_lock_no_retry(self):
+        client = self._get_client()
+        client.start()
+        # Try to get a lock on a path without a leading slash.
+        lock = client.Lock(self.lockpath[1:], "one")
+        try:
+            lock.acquire(timeout=0)
+        finally:
+            # Cleanup
+            client.stop()
 
 class TestSemaphore(KazooTestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #288.

Note that `lock._inner_acquire` already has correct behavior when it retries, so this diff should have two effects when paths without leading slashes are used: it should make locks slightly faster to acquire, and it should make very-small-timeouts less likely to result in crashes.
