### PR TITLE
Fix potential leak in DataWatch and ChildrenWatch

### DIFF
--- a/kazoo/recipe/watchers.py
+++ b/kazoo/recipe/watchers.py
@@ -163,6 +163,7 @@ class DataWatch(object):
                 result = self._func(data, stat)
             if result is False:
                 self._stopped = True
+                self._func = None
                 self._client.remove_listener(self._session_watcher)
         except Exception as exc:
             log.exception(exc)
@@ -333,6 +334,7 @@ class ChildrenWatch(object):
                     result = self._func(children)
                 if result is False:
                     self._stopped = True
+                    self._func = None
             except Exception as exc:
                 log.exception(exc)
                 raise


### PR DESCRIPTION
If the func passed to DataWatcher or ChildrenWatch is bound to an object it
will keep a reference to the object around which could prevent it from getting
garbage collected.
