### PR TITLE
Resolve hosts so that we properly randomize any round robin RRsets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+2.X.Y (TBD)
+-----------
+
+Features
+********
+
+Bug Handling
+************
+- #360: fully resolve multiple records for hosts in the zookeeper connection string
+
+Documentation
+*************
+
 2.2.1 (2015-06-17)
 ------------------
 

--- a/kazoo/hosts.py
+++ b/kazoo/hosts.py
@@ -21,7 +21,7 @@ def collect_hosts(hosts, randomize=True):
 
         # Resolve the hosts in case we are dealing with a round robin set
         for rhost in socket.getaddrinfo(host.strip(), port, 0, 0, socket.IPPROTO_TCP):
-            result.append(rhost[4])
+            result.append((rhost[4][0], rhost[4][1]))
 
     if randomize:
         random.shuffle(result)

--- a/kazoo/hosts.py
+++ b/kazoo/hosts.py
@@ -1,4 +1,5 @@
 import random
+import socket
 
 from six.moves import urllib_parse
 
@@ -17,7 +18,10 @@ def collect_hosts(hosts, randomize=True):
         if host is None:
             raise ValueError("bad hostname")
         port = int(res.port) if res.port else 2181
-        result.append((host.strip(), port))
+
+        # Resolve the hosts in case we are dealing with a round robin set
+        for rhost in socket.getaddrinfo(host.strip(), port, 0, 0, socket.IPPROTO_TCP):
+            result.append(rhost[4])
 
     if randomize:
         random.shuffle(result)

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -103,9 +103,7 @@ class TestClientConstructor(unittest.TestCase):
         eq_(hosts, [('127.0.0.1', 9), ('127.0.0.2', 9)])
 
     def test_invalid_hostname(self):
-        client = self._makeOne(hosts='nosuchhost/a')
-        timeout = client.handler.timeout_exception
-        self.assertRaises(timeout, client.start, 0.1)
+        self.assertRaises(socket.gaierror, self._makeOne, hosts='nosuchhost/a')
 
     def test_another_invalid_hostname(self):
         self.assertRaises(


### PR DESCRIPTION
When using a round-robin DNS record set for a Zookeeper ensemble (i.e. a single A record that points to all the IP addresses of the servers in the ensemble), we found that Kazoo was always connecting to the same server. It appears that the underlying socket calls that Kazoo uses to set up connections do not rotate the addresses in a round robin properly (if at all).

The simplest solution to this is to use a call to `socket.getaddrinfo` in the `collect_hosts` method when compiling the list of hosts from the connect string. This allows any hostnames to be dereferenced and provides a full set of IP addresses that can then be randomized by the client. This works regardless of whether a hostname, an IPv4, or an IPv6 address is provided, as `socket.getaddrinfo` handles it properly and returns the tuples needed for the socket calls.