### PR TITLE
remove listener in watchers.ChildrenWatch

### DIFF
--- a/kazoo/recipe/watchers.py
+++ b/kazoo/recipe/watchers.py
@@ -333,6 +333,7 @@ class ChildrenWatch(object):
                     result = self._func(children)
                 if result is False:
                     self._stopped = True
+                    self._client.remove_listener(self._session_watcher)
             except Exception as exc:
                 log.exception(exc)
                 raise


### PR DESCRIPTION
I believe that without this, the watch will remain in place forever,
even if it won't really call the callback again.  The inserted line was
copied straight out of watchers.DataWatch, which follows the same
general design as ChildrenWatch.
