### PR TITLE
Check connection_retry and command_retry types

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -217,11 +217,17 @@ class KazooClient(object):
             self._conn_retry = KazooRetry(**connection_retry)
         elif type(connection_retry) is KazooRetry:
             self._conn_retry = connection_retry
+        elif connection_retry is not None:
+            raise ConfigurationError("Unexpected connection_retry type %r"
+                                     % connection_retry)
 
         if type(command_retry) is dict:
             self.retry = KazooRetry(**command_retry)
         elif type(command_retry) is KazooRetry:
             self.retry = command_retry
+        elif command_retry is not None:
+            raise ConfigurationError("Unexpected command_retry type %r"
+                                     % command_retry)
 
         if type(self._conn_retry) is KazooRetry:
             if self.handler.sleep_func != self._conn_retry.sleep_func:

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -82,6 +82,22 @@ class TestClientConstructor(unittest.TestCase):
             ConfigurationError,
             self._makeOne, handler=SequentialThreadingHandler)
 
+    def test_invalid_connection_retry_type(self):
+        self.assertRaises(
+            ConfigurationError,
+            self._makeOne,
+            hosts='127.0.0.1:2181/',
+            connection_retry='a string',
+        )
+
+    def test_invalid_command_retry_type(self):
+        self.assertRaises(
+            ConfigurationError,
+            self._makeOne,
+            hosts='127.0.0.1:2181/',
+            command_retry='a string',
+        )
+
     def test_chroot(self):
         self.assertEqual(self._makeOne(hosts='127.0.0.1:2181/').chroot, '')
         self.assertEqual(self._makeOne(hosts='127.0.0.1:2181/a').chroot, '/a')


### PR DESCRIPTION
3rd party libraries and users might try to pass connection_retry or command_retry as integers or strigs: raise ConfigurationError on invalid types
