### PR TITLE
Add break_lock method to semaphores

### DIFF
--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -245,6 +245,17 @@ class Lock(object):
     def acquired_lock(self, children, index):
         return index == 0
 
+    def break_lock(self):
+        children = self._get_sorted_children()
+        # remove the first one
+        if not len(children):
+            return False
+        try:
+            self._delete_node(children[0])
+        except NoNodeError:
+            return False
+        return True
+
     def _watch_predecessor(self, event):
         self.wake_event.set()
 
@@ -554,6 +565,10 @@ class Semaphore(object):
             pass
         self.is_acquired = False
         return True
+
+    def break_lock(self):
+        lock = self.client.Lock(self.path, self.data)
+        return lock.break_lock()
 
     def lease_holders(self):
         """Return an unordered list of the current lease holders.

--- a/kazoo/tests/test_lock.py
+++ b/kazoo/tests/test_lock.py
@@ -624,6 +624,23 @@ class TestSemaphore(KazooTestCase):
         self.assertTrue(lock.cancelled)
         self.assertTrue(lock.acquire())
 
+    def test_break_lock(self):
+        lock = self.client.Semaphore(self.lockpath)
+        client2 = self._get_client()
+        client2.start()
+        client2.ensure_path("/")
+        lock2 = client2.Semaphore(self.lockpath)
+        self.assertTrue(lock.acquire(blocking=False))
+        self.assertTrue(lock2.break_lock())
+        self.assertTrue(lock2.acquire(blocking=False))
+        self.assertTrue(lock.release())
+        # Ensure lock2 is still the holder
+        client3 = self._get_client()
+        client3.start()
+        client3.ensure_path("/")
+        lock3 = client3.Semaphore(self.lockpath)
+        self.assertFalse(lock3.acquire(blocking=False))
+
     def test_timeout(self):
         timeout = 3
         e = self.make_event()


### PR DESCRIPTION
These may end up being broken through external means, so this method is
used for testing how that scenario is handled. It may also prove useful
for administrative tooling.
