### PR TITLE
Include docs in the built packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,4 +9,5 @@ exclude Makefile
 exclude run_failure.py
 recursive-include kazoo *
 recursive-exclude sw *
+recursive-include docs *
 global-exclude *pyc *pyo


### PR DESCRIPTION
Seems like people would like the docs included
in the package output, so ensure we pick them
up.

Fixes issue #379