### PR TITLE
Locks should ignore non-lock node children

### DIFF
--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -254,6 +254,7 @@ class Lock(object):
         # can't just sort directly: the node names are prefixed by uuids
         lockname = self._NODE_NAME
 
+        # only consider children that were created for this lock
         children = list(filter(lambda c: lockname in c, children))
         children.sort(key=lambda c: c[c.find(lockname) + len(lockname):])
         return children

--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -253,6 +253,8 @@ class Lock(object):
 
         # can't just sort directly: the node names are prefixed by uuids
         lockname = self._NODE_NAME
+        
+        children = filter(lambda c: lockname in c, children)
         children.sort(key=lambda c: c[c.find(lockname) + len(lockname):])
         return children
 

--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -253,8 +253,8 @@ class Lock(object):
 
         # can't just sort directly: the node names are prefixed by uuids
         lockname = self._NODE_NAME
-        
-        children = filter(lambda c: lockname in c, children)
+
+        children = list(filter(lambda c: lockname in c, children))
         children.sort(key=lambda c: c[c.find(lockname) + len(lockname):])
         return children
 


### PR DESCRIPTION
Noticed that if a lock node has non-lock children the current logic would consider them in the list of candidates for the lock and if they happen to sort higher than the current correct format nobody will ever be able to acquire the lock.

Proposed fix is to filter out any such non-lock child nodes from consideration when sorting the list.
