### PR TITLE
Install NullHandler for kazoo logger

### DIFF
--- a/kazoo/__init__.py
+++ b/kazoo/__init__.py
@@ -1,1 +1,28 @@
 from .version import __version__
+
+
+import logging
+
+
+# From CPython 2.7/3.5 Lib/logging/__init__.py, for 2.6 compatibility.
+class NullHandler(logging.Handler):
+    """
+    This handler does nothing. It's intended to be used to avoid the
+    "No handlers could be found for logger XXX" one-off warning. This is
+    important for library code, which may contain code to log events. If a user
+    of the library does not configure logging, the one-off warning might be
+    produced; to avoid this, the library developer simply needs to instantiate
+    a NullHandler and add it to the top-level logger of the library module or
+    package.
+    """
+    def handle(self, record):
+        """Stub."""
+
+    def emit(self, record):
+        """Stub."""
+
+    def createLock(self):
+        self.lock = None
+
+
+logging.getLogger('kazoo').addHandler(NullHandler())


### PR DESCRIPTION
On Python 2.6 and 2.7 people see "No handlers could be found for logger kazoo". On Python 3, there is https://docs.python.org/3.2/library/logging.html#logging.lastResort so that certain log messages (WARNING level) will magically end up on stderr.

Also see: https://docs.python.org/3.4/howto/logging.html#configuring-logging-for-a-library

Since kazoo also targets 2.6 and 2.7, we should add the `NullHandler`. 

This will normalize kazoo's logging behavior across Python versions, and prevent the weird "No handlers could be found" error message. It will also prevent people from thinking they retrieve all kazoo log messages (they might assume so once they see some messages appear on stderr). Instead, it forces them to properly set up their logging infrastructure.

We should probably document clearly that the application that uses kazoo _should_ properly set up  logging (all that is requires is adding a handler to the root logger).

This might look weird, but in fact most established Python libraries install the NullHandler. Example boto: https://github.com/boto/boto3/blob/develop/boto3/__init__.py#L96

I have taken liberty to use the code from CPython 3.5 -- I feel that the missing handle/createLock methods in boto's code might backfire.
