### PR TITLE
Ensure pending watches are not dropped when connection is lost

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -193,7 +193,8 @@ class KazooClient(object):
         self._state = KeeperState.CLOSED
         self.state = KazooState.LOST
         self.state_listeners = set()
-
+        self._child_watchers = defaultdict(set)
+        self._data_watchers = defaultdict(set)
         self._reset()
         self.read_only = read_only
 

--- a/kazoo/protocol/states.py
+++ b/kazoo/protocol/states.py
@@ -93,13 +93,19 @@ class EventType(object):
         removed). This event does not indicate the data for a child
         node has changed, which must have its own watch established.
 
+    .. attribute:: NONE
+
+        The connection state has been altered.
+
     """
     CREATED = 'CREATED'
     DELETED = 'DELETED'
     CHANGED = 'CHANGED'
     CHILD = 'CHILD'
+    NONE = 'NONE'
 
 EVENT_TYPE_MAP = {
+    -1:EventType.NONE,
     1: EventType.CREATED,
     2: EventType.DELETED,
     3: EventType.CHANGED,

--- a/kazoo/recipe/watchers.py
+++ b/kazoo/recipe/watchers.py
@@ -338,7 +338,8 @@ class ChildrenWatch(object):
                 raise
 
     def _watcher(self, event):
-        self._get_children(event)
+        if event.type != "NONE":
+            self._get_children(event)
 
     def _session_watcher(self, state):
         if state in (KazooState.LOST, KazooState.SUSPENDED):

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -414,6 +414,22 @@ class TestConnection(KazooTestCase):
             client._state = oldstate
             client._connection._write_sock = None
 
+    def test_watch_trigger_expire(self):
+        client = self.client
+        cv = self.make_event()
+
+        client.create("/test", b"")
+
+        def test_watch(event):
+            cv.set()
+
+        client.get("/test/", watch=test_watch)
+        self.expire_session(self.make_event)
+
+
+        cv.wait(3)
+        assert cv.is_set()
+
 
 class TestClient(KazooTestCase):
     def _makeOne(self, *args):


### PR DESCRIPTION
This behavior matches the reference implementation
Introduces a NONE event 
