### PR TITLE
Close the ChildrenWatch if the node doesn't exist. 

### DIFF
--- a/kazoo/recipe/watchers.py
+++ b/kazoo/recipe/watchers.py
@@ -315,8 +315,13 @@ class ChildrenWatch(object):
             if self._stopped:
                 return
 
-            children = self._client.retry(self._client.get_children,
-                                          self._path, self._watcher)
+            try:
+                children = self._client.retry(self._client.get_children,
+                                              self._path, self._watcher)
+            except NoNodeError:
+                self._stopped = True
+                return
+
             if not self._watch_established:
                 self._watch_established = True
 

--- a/kazoo/tests/test_watchers.py
+++ b/kazoo/tests/test_watchers.py
@@ -171,6 +171,46 @@ class KazooDataWatcherTests(KazooTestCase):
 
         eq_(args, [None, None])
 
+    def test_no_such_node_for_children_watch(self):
+        args = []
+        path = self.path + '/test_no_such_node_for_children_watch'
+        update = threading.Event()
+
+        def changed(children):
+            args.append(children)
+            update.set()
+
+        # watch a node which does not exist
+        children_watch = self.client.ChildrenWatch(path, changed)
+        eq_(update.is_set(), False)
+        eq_(children_watch._stopped, True)
+        eq_(args, [])
+
+        # watch a node which exists
+        self.client.create(path, b'')
+        children_watch = self.client.ChildrenWatch(path, changed)
+        update.wait(3)
+        eq_(args, [[]])
+        update.clear()
+
+        # watch changes
+        self.client.create(path + '/fred', b'')
+        update.wait(3)
+        eq_(args, [[], ['fred']])
+        update.clear()
+
+        # delete children
+        self.client.delete(path + '/fred')
+        update.wait(3)
+        eq_(args, [[], ['fred'], []])
+        update.clear()
+
+        # delete watching
+        self.client.delete(path)
+        time.sleep(1)
+        eq_(update.is_set(), False)
+        eq_(children_watch._stopped, True)
+
     def test_bad_watch_func2(self):
         counter = 0
 

--- a/kazoo/tests/test_watchers.py
+++ b/kazoo/tests/test_watchers.py
@@ -207,7 +207,15 @@ class KazooDataWatcherTests(KazooTestCase):
 
         # delete watching
         self.client.delete(path)
-        time.sleep(1)
+
+        # a hack for waiting the watcher stop
+        for retry in range(5):
+            if children_watch._stopped:
+                break
+            children_watch._run_lock.acquire()
+            children_watch._run_lock.release()
+            time.sleep(retry / 10.0)
+
         eq_(update.is_set(), False)
         eq_(children_watch._stopped, True)
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,9 @@ commands = flake8 {posargs}
 [testenv]
 usedevelop = True
 install_command = pip install {opts} {packages}
-setenv = VIRTUAL_ENV={envdir}
+setenv =
+    VIRTUAL_ENV={envdir}
+    ZOOKEEPER_VERSION={env:ZOOKEEPER_VERSION:}
 deps = -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_sphinx.txt
 commands = {toxinidir}/ensure-zookeeper-env.sh nosetests {posargs: -d -v --with-coverage kazoo.tests}


### PR DESCRIPTION
This implementation resolves the "NoNodeError" while watching children.

Fix #149.