### PR TITLE
System call interrupts

### DIFF
--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -147,8 +147,8 @@ class SequentialThreadingHandler(object):
         timeout = args[3] if len(args) == 4 else None
         # either the time to give up, or None
         end = (time.time() + timeout) if timeout else None
-        while timeout is None or time.time() < end:
-            if timeout:
+        while end is None or time.time() < end:
+            if end is not None:
                 args = list(args)  # make a list, since tuples aren't mutable
                 args[3] = end - time.time()  # set the timeout to the remaining time
             try:
@@ -161,6 +161,8 @@ class SequentialThreadingHandler(object):
                 if errnum == errno.EINTR:
                     continue
                 raise
+        # if we hit our timeout, lets return as a timeout
+        return ([], [], [])
 
     def socket(self):
         return utils.create_tcp_socket(socket)


### PR DESCRIPTION
This is a followup to #250

This PR includes 2 patches both fixing more interrupt issues. Basically this is an upstream issue (in python-- http://bugs.python.org/issue20611).

The first patch changes my previous fix (#250) from raising a timeout to retrying-- the issue we see is that the rest of the kazoo code assumes that a timeout is a timeout (which is reasonable). So instead of reworking all timeouts within kazoo, we can simply retry.

The second patch handles the same during connection setup.