### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: python-setuptools (>= 0.6b3),
                debhelper (>= 8.0.0),
                python-sphinx (>= 1.0.7+dfsg) | python3-sphinx,
 Standards-Version: 3.9.3
-Homepage: https://kazoo.readthedocs.org
+Homepage: https://kazoo.readthedocs.io
 X-Python-Version: >= 2.6
 
 Package: python-kazoo

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     keywords='zookeeper lock leader configuration',
     author="Kazoo team",
     author_email="python-zk@googlegroups.com",
-    url="https://kazoo.readthedocs.org",
+    url="https://kazoo.readthedocs.io",
     license="Apache 2.0",
     packages=find_packages(),
     test_suite="kazoo.tests",


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
