### PR TITLE
Counter: expose the previous and changed values.

### DIFF
--- a/kazoo/tests/test_counter.py
+++ b/kazoo/tests/test_counter.py
@@ -33,3 +33,15 @@ class KazooCounterTests(KazooTestCase):
         counter = self._makeOne()
         self.assertRaises(TypeError, counter.__add__, 2.1)
         self.assertRaises(TypeError, counter.__add__, b"a")
+
+    def test_pre_post_values(self):
+        counter = self._makeOne()
+        eq_(counter.value, 0)
+        eq_(counter.pre_value, None)
+        eq_(counter.post_value, None)
+        counter += 2
+        eq_(counter.pre_value, 0)
+        eq_(counter.post_value, 2)
+        counter -= 3
+        eq_(counter.pre_value, 2)
+        eq_(counter.post_value, -1)


### PR DESCRIPTION
This commit extends the `Counter` API with the `pre_value` and
`post_value` attributes. These attributes are set when a counter
is changed. Previously, if the counter was modified concurrently,
it was not possible to access the exact value to which the counter
was set after a successful increment or decrement.
