### PR TITLE
Fix the client.add_auth hangs by xids mismatch.

### DIFF
--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -338,8 +338,10 @@ class ConnectionHandler(object):
         if header.zxid and header.zxid > 0:
             client.last_zxid = header.zxid
         if header.xid != xid:
-            raise RuntimeError('xids do not match, expected %r '
+            exc = RuntimeError('xids do not match, expected %r '
                                'received %r', xid, header.xid)
+            async_object.set_exception(exc)
+            raise exc
 
         # Determine if its an exists request and a no node error
         exists_error = (header.err == NoNodeError.code and


### PR DESCRIPTION
This commit fixes https://github.com/python-zk/kazoo/issues/229  by throwing the runtime exception into the dequeued `async_result`. It will end the waiting of user threading.

But this commit doesn't fix the xids mismatch itself (https://github.com/python-zk/kazoo/issues/254). The unordered xids may caused by a bug from the ZooKeeper server side, such as the official issues [ZOOKEEPER-1863](https://issues.apache.org/jira/browse/ZOOKEEPER-1863) described.
