### PR TITLE
#383 KazooTimeoutError should inherit kazooException

### DIFF
--- a/docs/api/handlers/eventlet.rst
+++ b/docs/api/handlers/eventlet.rst
@@ -16,3 +16,5 @@ Private API
 
   .. autoclass:: AsyncResult
      :members:
+
+  .. autoexception:: KazooTimeoutError

--- a/docs/api/handlers/threading.rst
+++ b/docs/api/handlers/threading.rst
@@ -17,4 +17,4 @@ Private API
   .. autoclass:: AsyncResult
      :members:
 
-  .. autoexception:: TimeoutError
+  .. autoexception:: KazooTimeoutError

--- a/kazoo/exceptions.py
+++ b/kazoo/exceptions.py
@@ -43,7 +43,11 @@ class WriterNotClosedException(KazooException):
     """
 
 
-class KazooTimeoutError(Exception):
+class TimeoutError(Exception):
+    pass
+
+
+class KazooTimeoutError(Exception, TimeoutError):
     pass
 
 

--- a/kazoo/exceptions.py
+++ b/kazoo/exceptions.py
@@ -47,6 +47,21 @@ class KazooTimeoutError(Exception):
     pass
 
 
+class ForceRetryError(Exception):
+    """Raised when some recipe logic wants to force a retry."""
+
+
+class RetryFailedError(KazooException):
+    """Raised when retrying an operation ultimately failed, after
+    retrying the maximum number of attempts.
+    """
+
+
+class InterruptedError(RetryFailedError):
+    """Raised when the retry is forcibly interrupted by the interrupt
+    function"""
+
+
 def _invalid_error_code():
     raise RuntimeError('Invalid error code')
 

--- a/kazoo/exceptions.py
+++ b/kazoo/exceptions.py
@@ -47,11 +47,11 @@ class TimeoutError(Exception):
     pass
 
 
-class KazooTimeoutError(Exception, TimeoutError):
+class KazooTimeoutError(KazooException, TimeoutError):
     pass
 
 
-class ForceRetryError(Exception):
+class ForceRetryError(KazooException):
     """Raised when some recipe logic wants to force a retry."""
 
 

--- a/kazoo/exceptions.py
+++ b/kazoo/exceptions.py
@@ -43,6 +43,10 @@ class WriterNotClosedException(KazooException):
     """
 
 
+class KazooTimeoutError(Exception):
+    pass
+
+
 def _invalid_error_code():
     raise RuntimeError('Invalid error code')
 

--- a/kazoo/handlers/eventlet.py
+++ b/kazoo/handlers/eventlet.py
@@ -13,6 +13,7 @@ from eventlet.green import time as green_time
 from eventlet.green import threading as green_threading
 from eventlet import queue as green_queue
 
+from kazoo.exceptions import KazooTimeoutError, TimeoutError
 from kazoo.handlers import utils
 
 LOG = logging.getLogger(__name__)
@@ -35,16 +36,12 @@ def _yield_before_after():
         eventlet.sleep(0)
 
 
-class TimeoutError(Exception):
-    pass
-
-
 class AsyncResult(utils.AsyncResult):
     """A one-time event that stores a value or an exception"""
     def __init__(self, handler):
         super(AsyncResult, self).__init__(handler,
                                           green_threading.Condition,
-                                          TimeoutError)
+                                          KazooTimeoutError)
 
 
 class SequentialEventletHandler(object):
@@ -92,7 +89,7 @@ class SequentialEventletHandler(object):
     def running(self):
         return self._started
 
-    timeout_exception = TimeoutError
+    timeout_exception = KazooTimeoutError
 
     def _process_completion_queue(self):
         while True:

--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -19,6 +19,7 @@ import socket
 import threading
 import time
 
+from kazoo.exceptions import KazooTimeoutError
 import kazoo.python2atexit as python2atexit
 
 try:
@@ -32,10 +33,6 @@ from kazoo.handlers import utils
 _STOP = object()
 
 log = logging.getLogger(__name__)
-
-
-class KazooTimeoutError(Exception):
-    pass
 
 
 class AsyncResult(utils.AsyncResult):

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -13,6 +13,8 @@ from kazoo.exceptions import (
     AuthFailedError,
     ConnectionDropped,
     EXCEPTIONS,
+    ForceRetryError,
+    RetryFailedError,
     SessionExpiredError,
     NoNodeError
 )
@@ -36,10 +38,7 @@ from kazoo.protocol.states import (
     WatchedEvent,
     EVENT_TYPE_MAP,
 )
-from kazoo.retry import (
-    ForceRetryError,
-    RetryFailedError
-)
+
 
 log = logging.getLogger(__name__)
 

--- a/kazoo/recipe/counter.py
+++ b/kazoo/recipe/counter.py
@@ -6,7 +6,7 @@
 """
 
 from kazoo.exceptions import BadVersionError
-from kazoo.retry import ForceRetryError
+from kazoo.exceptions import ForceRetryError
 
 
 class Counter(object):

--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -24,16 +24,16 @@ import uuid
 
 import six
 
-from kazoo.retry import (
-    KazooRetry,
-    RetryFailedError,
-    ForceRetryError
-)
-from kazoo.exceptions import CancelledError
-from kazoo.exceptions import KazooException
-from kazoo.exceptions import LockTimeout
-from kazoo.exceptions import NoNodeError
 from kazoo.protocol.states import KazooState
+from kazoo.exceptions import (
+    CancelledError,
+    ForceRetryError,
+    KazooException,
+    LockTimeout,
+    NoNodeError,
+    RetryFailedError
+)
+from kazoo.retry import KazooRetry
 
 
 class _Watch(object):

--- a/kazoo/recipe/queue.py
+++ b/kazoo/recipe/queue.py
@@ -11,8 +11,11 @@
 """
 
 import uuid
-from kazoo.exceptions import NoNodeError, NodeExistsError
-from kazoo.retry import ForceRetryError
+from kazoo.exceptions import (
+    NoNodeError,
+    NodeExistsError,
+    ForceRetryError
+)
 from kazoo.protocol.states import EventType
 
 

--- a/kazoo/retry.py
+++ b/kazoo/retry.py
@@ -8,24 +8,13 @@ from kazoo.exceptions import (
     KazooException,
     OperationTimeoutError,
     SessionExpiredError,
+    ForceRetryError,
+    InterruptedError,
+    RetryFailedError
 )
 
+
 log = logging.getLogger(__name__)
-
-
-class ForceRetryError(Exception):
-    """Raised when some recipe logic wants to force a retry."""
-
-
-class RetryFailedError(KazooException):
-    """Raised when retrying an operation ultimately failed, after
-    retrying the maximum number of attempts.
-    """
-
-
-class InterruptedError(RetryFailedError):
-    """Raised when the retry is forcibly interrupted by the interrupt
-    function"""
 
 
 class KazooRetry(object):

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -91,7 +91,7 @@ class TestClientConstructor(unittest.TestCase):
             hosts='127.0.0.1:2181,127.0.0.1:2182/a/b').chroot, '/a/b')
 
     def test_connection_timeout(self):
-        from kazoo.handlers.threading import KazooTimeoutError
+        from kazoo.exceptions import KazooTimeoutError
         client = self._makeOne(hosts='127.0.0.1:9')
         self.assertTrue(client.handler.timeout_exception is KazooTimeoutError)
         self.assertRaises(KazooTimeoutError, client.start, 0.1)

--- a/kazoo/tests/test_retry.py
+++ b/kazoo/tests/test_retry.py
@@ -9,7 +9,7 @@ class TestRetrySleeper(unittest.TestCase):
         pass
 
     def _fail(self, times=1):
-        from kazoo.retry import ForceRetryError
+        from kazoo.exceptions import ForceRetryError
         scope = dict(times=0)
 
         def inner():


### PR DESCRIPTION
leaving `kazoo.protocol.connection.RWServerAvailable` where it is since it's more a logical event handler than a KazooException.
