### PR TITLE
Build python 2 and 3 universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [easy_install]
 
 [egg_info]


### PR DESCRIPTION
In order to build a python 2 and 3 universal wheel the bdist_wheel configuration must be added to setup.cfg.
