### PR TITLE
Manage session expirations with connection timeout

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -195,6 +195,7 @@ class KazooClient(object):
         self.read_only = read_only
 
         if client_id:
+            self._session_expiration = None
             self._session_id = client_id[0]
             self._session_passwd = client_id[1]
         else:
@@ -309,6 +310,7 @@ class KazooClient(object):
         self._data_watchers = defaultdict(set)
 
     def _reset_session(self):
+        self._session_expiration = None
         self._session_id = None
         self._session_passwd = b'\x00' * 16
 

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -600,6 +600,10 @@ class ConnectionHandler(object):
                         client._session_id,
                         hexlify(client._session_passwd))
 
+        if client._session_expiration is not None:
+            if client._session_expiration < time.clock():
+                raise SessionExpiredError("Session has expired")
+
         with self._socket_error_handling():
             self._socket = self.handler.create_connection(
                 (host, port), client._session_timeout / 1000.0)
@@ -626,6 +630,7 @@ class ConnectionHandler(object):
         connect_timeout = negotiated_session_timeout / len(client.hosts)
         read_timeout = negotiated_session_timeout * 2.0 / 3.0
         client._session_passwd = connect_result.passwd
+        client._session_expiration = time.clock() + negotiated_session_timeout
 
         self.logger.log(BLATHER,
                         'Session created, session_id: %r session_passwd: %s\n'


### PR DESCRIPTION
Before this change, kazoo is getting a TimeoutError (transformed into a
ConnectionDropped error by the _socket_error_handling manager), which
doesn't let the zk loop know that it should stop connecting, even long
after the session has expired. It means that kazoo was forever looping,
trying to get a new connection.