### PR TITLE
Let the client keep the session open when closing

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -108,7 +108,7 @@ class KazooClient(object):
                  timeout=10.0, client_id=None, handler=None,
                  default_acl=None, auth_data=None, read_only=None,
                  randomize_hosts=True, connection_retry=None,
-                 command_retry=None, logger=None, **kwargs):
+                 command_retry=None, logger=None, keep_session=False, **kwargs):
         """Create a :class:`KazooClient` instance. All time arguments
         are in seconds.
 
@@ -137,6 +137,8 @@ class KazooClient(object):
             options which will be used for creating one.
         :param logger: A custom logger to use instead of the module
             global `log` instance.
+        :param keep_session: A boolean to decide if the session should
+            be closed or not when closing the connection.
 
         Basic Example:
 
@@ -199,6 +201,8 @@ class KazooClient(object):
             self._session_passwd = client_id[1]
         else:
             self._reset_session()
+
+        self._keep_session = keep_session
 
         # ZK uses milliseconds
         self._session_timeout = int(timeout * 1000)
@@ -300,7 +304,6 @@ class KazooClient(object):
         self._pending = deque()
 
         self._reset_watchers()
-        self._reset_session()
         self.last_zxid = 0
         self._protocol_version = None
 
@@ -594,7 +597,10 @@ class KazooClient(object):
             return
 
         self._stopped.set()
-        self._queue.append((CloseInstance, None))
+        if self._keep_session:
+            self._queue.append((None, None))
+        else:
+            self._queue.append((CloseInstance, None))
         self._connection._write_sock.send(b'\0')
         self._safe_close()
 

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -435,6 +435,12 @@ class ConnectionHandler(object):
         if request is _CONNECTION_DROP:
             raise ConnectionDropped("Connection dropped: Testing")
 
+        # Special case when keeping the session after closing
+        if request is None:
+            client._queue.popleft()
+            self._read_sock.recv(1)
+            return CLOSE_RESPONSE
+
         # Special case for auth packets
         if request.type == Auth.type:
             xid = AUTH_XID
@@ -559,7 +565,11 @@ class ConnectionHandler(object):
                         response = self._read_socket(read_timeout)
                         close_connection = response == CLOSE_RESPONSE
                     else:
-                        self._send_request(read_timeout, connect_timeout)
+                        response = self._send_request(
+                            read_timeout,
+                            connect_timeout,
+                        )
+                        close_connection = response == CLOSE_RESPONSE
             self.logger.info('Closing connection to %s:%s', host, port)
             client._session_callback(KeeperState.CLOSED)
             return STOP_CONNECTING


### PR DESCRIPTION
The use case is being able to restart a process (e.g. software upgrade)
and not losing the ephemeral nodes. The process can save the session id
and password in a file, reload them at boot time, and load the kazoo
client with the previous session id.
