### PR TITLE
Always call _safe_close() on KazooClient.stop() so we don't leak work…

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -595,8 +595,10 @@ class KazooClient(object):
 
         self._stopped.set()
         self._queue.append((CloseInstance, None))
-        self._connection._write_sock.send(b'\0')
-        self._safe_close()
+        try:
+            self._connection._write_sock.send(b'\0')
+        finally:
+            self._safe_close()
 
     def restart(self):
         """Stop and restart the Zookeeper session."""


### PR DESCRIPTION
…er threads

Use a try/finally so that errors sending the null character over _write_sock don't cause the KazooClient to skip self._safe_close()