### PR TITLE
Restrict gevent for older versions and newer versions

### DIFF
--- a/requirements_gevent.txt
+++ b/requirements_gevent.txt
@@ -1,1 +1,2 @@
-gevent>=1.0.2
+gevent>1.1; python_version>='2.7'
+gevent<=1.1; python_version=='2.6'


### PR DESCRIPTION
Gevent >= 1.1 is not py2.6 compat; so use the requirements
python version restriction mechanism to restrict what
versions work on older versions of python.