### PR TITLE
Client is now context aware

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -294,6 +294,13 @@ class KazooClient(object):
             raise TypeError('__init__() got unexpected keyword arguments: %s'
                             % (kwargs.keys(),))
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self):
+        self.stop()
+        self.close()
+
     def _reset(self):
         """Resets a variety of client states for a new connection."""
         self._queue = deque()

--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -297,7 +297,7 @@ class KazooClient(object):
     def __enter__(self):
         return self
 
-    def __exit__(self):
+    def __exit__(self, exception_type, exception_value, traceback):
         self.stop()
         self.close()
 


### PR DESCRIPTION
Ran into an issue today where ZK was struggling and this was partially due to the unexpected behavior surrounding .stop vs .close.

This change allows the client to be used as a context and does the "right" thing for cleanup.

Thanks for considering!