### PR TITLE
fix deadlock in nonblocking semaphore acquiring

### DIFF
--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -472,10 +472,10 @@ class Semaphore(object):
         w = _Watch(duration=timeout)
         w.start()
         lock = self.client.Lock(self.lock_path, self.data)
-        gotten = lock.acquire(blocking=blocking, timeout=w.leftover())
-        if not gotten:
-            return False
         try:
+            gotten = lock.acquire(blocking=blocking, timeout=w.leftover())
+            if not gotten:
+                return False
             while True:
                 self.wake_event.clear()
 


### PR DESCRIPTION
Issue #429 fix

fix deadlock in nonblocking semaphore acquiring by doing semaphore inner lock release for every lock acquiring attempt