### PR TITLE
chore: update MANIFEST.in to reflect changes to filenames

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
-include CHANGES.rst
-include CONTRIBUTING.rst
-include README.rst
+include CHANGES.md
+include CONTRIBUTING.md
+include README.md
 include LICENSE
 include MANIFEST.in
 exclude .gitignore


### PR DESCRIPTION
Looks like the .rst files got converted to .md, but MANIFEST.in wasn't
updated.  This also fixes the sdist, since setup.py expects README.md &
CONTRIBUTING.md to be in the source tarball.

Closes #437