### PR TITLE
Add missed parens to function call.

### DIFF
--- a/kazoo/recipe/queue.py
+++ b/kazoo/recipe/queue.py
@@ -271,7 +271,7 @@ class LockingQueue(BaseQueue):
         :rtype: bool
 
         """
-        if self.processing_element is not None and self.holds_lock:
+        if self.processing_element is not None and self.holds_lock():
             id_, value = self.processing_element
             with self.client.transaction() as transaction:
                 transaction.delete("{path}/{id}".format(


### PR DESCRIPTION
The second clause of the conditional (checking if the lock is held) will always evaluate to True.