### PR TITLE
chore: remove `easy_install` instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,7 +4,7 @@
 Installing
 ==========
 
-kazoo can be installed via ``pip`` or ``easy_install``:
+kazoo can be installed via ``pip``:
 
 .. code-block:: bash
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,8 +5,6 @@ release = clean_egg_info sdist bdist_wheel
 [bdist_wheel]
 universal = 1
 
-[easy_install]
-
 [egg_info]
 tag_build = dev
 


### PR DESCRIPTION
Everyone uses `pip` these days.