### PR TITLE
chore: remove python 3.3 from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist =
     py27,
     py27-gevent,
     py27-eventlet,
-    py33,
     py34,
     py35,
     py36,


### PR DESCRIPTION
Looks like removing this was overlooked in https://github.com/python-zk/kazoo/commit/2faba9ff3bdeff151ac6c922bf65b2dcf9c7bd7b