### PR TITLE
chore: stop bundling virtualenv and assorted fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ site-packages/
 zookeeper/
 .coverage
 .idea
-.pip_cache
 .project
 .pydevproject
 .tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ addons:
     packages:
     - libevent-dev
 cache:
+  pip: true
   directories:
-  - "$HOME/.cache/pip"
   - zookeeper
 language: python
 python:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,7 @@
 HERE = $(shell pwd)
 BIN = $(HERE)/bin
 PYTHON = $(BIN)/python
-PIP_DOWNLOAD_CACHE ?= $(HERE)/.pip_cache
 INSTALL = $(BIN)/pip install
-ifneq ($(TRAVIS), true)
-    INSTALL += --download-cache $(PIP_DOWNLOAD_CACHE)
-endif
 TOX_VENV ?= py27
 BUILD_DIRS = bin build include lib lib64 man share
 

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ TRAVIS_PYTHON_VERSION ?= $(shell $(PYTHON_EXE) -c "import sys; print('.'.join([s
 GREENLET_SUPPORTED = yes
 ifeq ($(findstring 3.,$(TRAVIS_PYTHON_VERSION)), 3.)
 	GREENLET_SUPPORTED = no
-	VENV_CMD = python -m venv .
+	VENV_CMD = $(PYTHON_EXE) -m venv .
 else
-	VENV_CMD = python -m virtualenv .
+	VENV_CMD = $(PYTHON_EXE) -m virtualenv .
 endif
 ifeq ($(PYPY),yes)
 	GREENLET_SUPPORTED = no

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ INSTALL = $(BIN)/pip install
 TOX_VENV ?= py27
 BUILD_DIRS = bin build include lib lib64 man share
 
-GEVENT_VERSION ?= 1.0.1
 PYTHON_EXE = $(shell [ -f $(PYTHON) ] && echo $(PYTHON) || echo python)
 PYPY = $(shell $(PYTHON_EXE) -c "import sys; print(getattr(sys, 'pypy_version_info', False) and 'yes' or 'no')")
 TRAVIS ?= false
@@ -33,7 +32,6 @@ build: $(PYTHON)
 ifeq ($(GREENLET_SUPPORTED),yes)
 	$(INSTALL) -U -r requirements_eventlet.txt
 	$(INSTALL) -U -r requirements_gevent.txt
-	$(INSTALL) -f https://github.com/surfly/gevent/releases gevent==$(GEVENT_VERSION)
 endif
 ifneq ($(TRAVIS), true)
 	$(INSTALL) -U -r requirements_sphinx.txt

--- a/kazoo/tests/test_build.py
+++ b/kazoo/tests/test_build.py
@@ -12,15 +12,6 @@ class TestBuildEnvironment(KazooTestCase):
         if not os.environ.get('TRAVIS'):
             raise SkipTest('Only run build config tests on Travis.')
 
-    def test_gevent_version(self):
-        try:
-            import gevent
-        except ImportError:
-            raise SkipTest('gevent not available.')
-        env_version = os.environ.get('GEVENT_VERSION')
-        if env_version:
-            self.assertEqual(env_version, gevent.__version__)
-
     def test_zookeeper_version(self):
         server_version = self.client.server_version()
         server_version = '.'.join([str(i) for i in server_version])


### PR DESCRIPTION
This is a continuation of #467.

I needed all those fixes in order to get `make` run again on my mac.