### PR TITLE
Drop python 2.6 compatible gevent

### DIFF
--- a/requirements_gevent.txt
+++ b/requirements_gevent.txt
@@ -1,2 +1,1 @@
-gevent>1.1; python_version>='2.7'
-gevent<=1.1; python_version=='2.6'
+gevent>1.1


### PR DESCRIPTION
We dropped python 2.6 support a while ago, so no need for the added complexity here.