### PR TITLE
fix: need gevent >= 1.2, not > 1.1

### DIFF
--- a/requirements_gevent.txt
+++ b/requirements_gevent.txt
@@ -1,1 +1,1 @@
-gevent>1.1
+gevent>=1.2

--- a/setup.py
+++ b/setup.py
@@ -28,16 +28,16 @@ tests_require = install_requires + [
 
 if not (PYTHON3 or PYPY):
     tests_require += [
-        'gevent',
-        'eventlet',
+        'gevent>=1.2',
+        'eventlet>=0.17.1',
     ]
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if on_rtd:
-    install_requires.extend([
-        'gevent',
-        'eventlet',
-    ])
+    install_requires += [
+        'gevent>=1.2',
+        'eventlet>=0.17.1',
+    ]
 
 setup(
     name='kazoo',


### PR DESCRIPTION
Python 2.6 support was dropped in 1.2, so https://github.com/python-zk/kazoo/commit/2e8dcd3836d01640f07e8de911cdfb3639f97d20 simplified the dependency graph to require `gevent>1.1`. However, bugfix releases to the 1.1 series (1.1.1, etc) will satisfy this requirement, so we should actually be requiring `gevent >= 1.2`