### PR TITLE
Fix a batch of known issues of TreeCache recipe

### DIFF
--- a/kazoo/handlers/eventlet.py
+++ b/kazoo/handlers/eventlet.py
@@ -76,11 +76,13 @@ class SequentialEventletHandler(object):
 
     """
     name = "sequential_eventlet_handler"
+    queue_impl = green_queue.LightQueue
+    queue_empty = green_queue.Empty
 
     def __init__(self):
         """Create a :class:`SequentialEventletHandler` instance"""
-        self.callback_queue = green_queue.LightQueue()
-        self.completion_queue = green_queue.LightQueue()
+        self.callback_queue = self.queue_impl()
+        self.completion_queue = self.queue_impl()
         self._workers = []
         self._started = False
 

--- a/kazoo/handlers/gevent.py
+++ b/kazoo/handlers/gevent.py
@@ -7,8 +7,6 @@ import gevent
 from gevent import socket
 import gevent.event
 import gevent.queue
-from gevent.queue import Empty
-from gevent.queue import Queue
 import gevent.select
 import gevent.thread
 try:
@@ -50,11 +48,13 @@ class SequentialGeventHandler(object):
 
     """
     name = "sequential_gevent_handler"
+    queue_impl = gevent.queue.Queue
+    queue_empty = gevent.queue.Empty
     sleep_func = staticmethod(gevent.sleep)
 
     def __init__(self):
         """Create a :class:`SequentialGeventHandler` instance"""
-        self.callback_queue = Queue()
+        self.callback_queue = self.queue_impl()
         self._running = False
         self._async = None
         self._state_change = Semaphore()
@@ -72,7 +72,7 @@ class SequentialGeventHandler(object):
                     if func is _STOP:
                         break
                     func()
-                except Empty:
+                except self.queue_empty:
                     continue
                 except Exception as exc:
                     log.warning("Exception in worker greenlet")
@@ -110,7 +110,7 @@ class SequentialGeventHandler(object):
                 worker.join()
 
             # Clear the queues
-            self.callback_queue = Queue()  # pragma: nocover
+            self.callback_queue = self.queue_impl()  # pragma: nocover
 
             python2atexit.unregister(self.stop)
 

--- a/kazoo/recipe/cache.py
+++ b/kazoo/recipe/cache.py
@@ -268,14 +268,14 @@ class TreeNode(object):
         # TODO max-depth checking support
         self._call_client('get_children', self._path)
 
-    def _call_client(self, method_name, path, *args):
+    def _call_client(self, method_name, path):
+        assert method_name in ('get', 'get_children', 'exists')
         self._tree._outstanding_ops += 1
         callback = functools.partial(
             self._tree._in_background, self._process_result,
             method_name, path)
-        kwargs = {'watch': self._process_watch}
         method = getattr(self._tree._client, method_name + '_async')
-        method(path, *args, **kwargs).rawlink(callback)
+        method(path, watch=self._process_watch).rawlink(callback)
 
     def _process_watch(self, watched_event):
         logger.debug('process_watch: %r', watched_event)
@@ -294,38 +294,35 @@ class TreeNode(object):
         logger.debug('process_result: %s %s', method_name, path)
         if method_name == 'exists':
             assert self._parent is None, 'unexpected EXISTS on non-root'
-            # the value of result will be set with `None` if node not exists.
-            if result.get() is not None:
+            # The result will be `None` if the node doesn't exist.
+            if result.successful() and result.get() is not None:
                 if self._state == self.STATE_DEAD:
                     self._state = self.STATE_PENDING
                 self.on_created()
         elif method_name == 'get_children':
-            try:
+            if result.successful():
                 children = result.get()
-            except NoNodeError:
-                self.on_deleted()
-            else:
                 for child in sorted(children):
                     full_path = os.path.join(path, child)
                     if child not in self._children:
                         node = TreeNode(self._tree, full_path, self)
                         self._children[child] = node
                         node.on_created()
-        elif method_name == 'get':
-            try:
-                data, stat = result.get()
-            except NoNodeError:
+            elif isinstance(result.exception, NoNodeError):
                 self.on_deleted()
-            else:
+        elif method_name == 'get':
+            if result.successful():
+                data, stat = result.get()
                 old_data, self._data = (
                     self._data, NodeData.make(path, data, stat))
-
                 old_state, self._state = self._state, self.STATE_LIVE
                 if old_state == self.STATE_LIVE:
                     if old_data is None or old_data.stat.mzxid != stat.mzxid:
                         self._publish_event(TreeEvent.NODE_UPDATED, self._data)
                 else:
                     self._publish_event(TreeEvent.NODE_ADDED, self._data)
+            elif isinstance(result.exception, NoNodeError):
+                self.on_deleted()
         else:  # pragma: no cover
             logger.warning('unknown operation %s', method_name)
             self._tree._outstanding_ops -= 1

--- a/kazoo/recipe/cache.py
+++ b/kazoo/recipe/cache.py
@@ -189,9 +189,9 @@ class TreeCache(object):
         if state == KazooState.SUSPENDED:
             self._publish_event(TreeEvent.CONNECTION_SUSPENDED)
         elif state == KazooState.CONNECTED:
-            with handle_exception(self._error_listeners):
-                self._root.on_reconnected()
-                self._publish_event(TreeEvent.CONNECTION_RECONNECTED)
+            # The session watcher should not be blocked
+            self._in_background(self._root.on_reconnected)
+            self._publish_event(TreeEvent.CONNECTION_RECONNECTED)
         elif state == KazooState.LOST:
             self._is_initialized = False
             self._publish_event(TreeEvent.CONNECTION_LOST)


### PR DESCRIPTION
This pull request fixes some edge bugs which were found in our production, and improves performance by approaching the behaviors of Apache Curator:

1. The new TreeCache uses a standalone background queue instead of using the Kazoo handler's one.
2. The new TreeCache ignores unknown exceptions of async operations instead of crashing.
3. The tree refreshing operations send `\0` to a pipe or socketpair for waking up the connection routine. Those operations will block the session watcher callback and has been moved to the background queue.

Thanks for @mozillazg for detecting those issues.