### PR TITLE
fix (recipe): don't set creation watch on lock predecessor node

### DIFF
--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -246,11 +246,14 @@ class Lock(object):
             predecessor = self.path + "/" + predecessor
             self.client.add_listener(self._watch_session)
             try:
-                if self.client.exists(predecessor, self._watch_predecessor):
-                    self.wake_event.wait(timeout)
-                    if not self.wake_event.isSet():
-                        raise LockTimeout("Failed to acquire lock on %s after "
-                                          "%s seconds" % (self.path, timeout))
+                self.client.get(predecessor, self._watch_predecessor)
+            except NoNodeError:
+                pass  # predecessor has already been deleted
+            else:
+                self.wake_event.wait(timeout)
+                if not self.wake_event.isSet():
+                    raise LockTimeout("Failed to acquire lock on %s after "
+                                      "%s seconds" % (self.path, timeout))
             finally:
                 self.client.remove_listener(self._watch_session)
 


### PR DESCRIPTION
Using exists will register a creation, as well as update and deletion
watch on the given node. This introduces a race, where the predecessor
node can get deleted between the call to getChildren() and exists().
If that happens, the exists() sets a create watch on a node that will
never be created, leaks a create watch.