### PR TITLE
client: Allow SSL use when communicating with Zookeeper, fixes #382

### DIFF
--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -3,6 +3,8 @@
 import errno
 import functools
 import select
+import ssl
+import socket
 import time
 
 HAS_FNCTL = True
@@ -182,7 +184,7 @@ def create_tcp_socket(module):
     return sock
 
 
-def create_tcp_connection(module, address, timeout=None):
+def create_tcp_connection(module, address, timeout=None, use_ssl=False, ca=None, certfile=None, keyfile=None):
     end = None
     if timeout is None:
         # thanks to create_connection() developers for
@@ -193,17 +195,40 @@ def create_tcp_connection(module, address, timeout=None):
     sock = None
 
     while end is None or time.time() < end:
-        try:
-            # if we got a timeout, lets ensure that we decrement the time
-            # otherwise there is no timeout set and we'll call it as such
-            timeout_at = end if end is None else end - time.time()
-            sock = module.create_connection(address, timeout_at)
-            break
-        except Exception as ex:
-            errnum = ex.errno if isinstance(ex, OSError) else ex[0]
-            if errnum == errno.EINTR:
-                continue
-            raise
+        if use_ssl:
+            # Disallow use of SSLv2 and V3 (meaning we require TLSv1.0+)
+            context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+            context.options |= ssl.OP_NO_SSLv2
+            context.options |= ssl.OP_NO_SSLv3
+            context.verify_mode = ssl.CERT_OPTIONAL
+            if ca:
+                context.load_verify_locations(ca)
+            if certfile and keyfile:
+                context.verify_mode = ssl.CERT_REQUIRED
+                context.load_cert_chain(certfile=certfile, keyfile=keyfile)
+            try:
+                # Query the address to get back it's address family
+                addrs = socket.getaddrinfo(address[0], address[1], 0, socket.SOCK_STREAM)
+                conn = context.wrap_socket(module.socket(addrs[0][0]))
+                conn.connect(address)
+                sock = conn
+                break
+            except ssl.SSLError:
+                raise
+        else:
+            try:
+                sock = module.create_connection(address, timeout)
+
+                # if we got a timeout, lets ensure that we decrement the time
+                # otherwise there is no timeout set and we'll call it as such
+                timeout_at = end if end is None else end - time.time()
+                sock = module.create_connection(address, timeout_at)
+                break
+            except Exception as ex:
+                errnum = ex.errno if isinstance(ex, OSError) else ex[0]
+                if errnum == errno.EINTR:
+                    continue
+                raise
 
     if sock is None:
         raise module.error


### PR DESCRIPTION
Zookeeper 3.5 supports SSL for client communications, this commit
adds support for it on the Kazoo side.

Note that you need to give the client the key, certificate and CA
files.