### PR TITLE
client: Allow SSL use when communicating with Zookeeper, fixes #382

### DIFF
--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -3,6 +3,8 @@
 import errno
 import functools
 import select
+import ssl
+import socket
 import time
 
 HAS_FNCTL = True
@@ -183,7 +185,8 @@ def create_tcp_socket(module):
     return sock
 
 
-def create_tcp_connection(module, address, timeout=None):
+def create_tcp_connection(module, address, timeout=None,
+                          use_ssl=False, ca=None, certfile=None, keyfile=None):
     end = None
     if timeout is None:
         # thanks to create_connection() developers for
@@ -194,17 +197,41 @@ def create_tcp_connection(module, address, timeout=None):
     sock = None
 
     while end is None or time.time() < end:
-        try:
-            # if we got a timeout, lets ensure that we decrement the time
-            # otherwise there is no timeout set and we'll call it as such
-            timeout_at = end if end is None else end - time.time()
-            sock = module.create_connection(address, timeout_at)
-            break
-        except Exception as ex:
-            errnum = ex.errno if isinstance(ex, OSError) else ex[0]
-            if errnum == errno.EINTR:
-                continue
-            raise
+        if use_ssl:
+            # Disallow use of SSLv2 and V3 (meaning we require TLSv1.0+)
+            context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+            context.options |= ssl.OP_NO_SSLv2
+            context.options |= ssl.OP_NO_SSLv3
+            context.verify_mode = ssl.CERT_OPTIONAL
+            if ca:
+                context.load_verify_locations(ca)
+            if certfile and keyfile:
+                context.verify_mode = ssl.CERT_REQUIRED
+                context.load_cert_chain(certfile=certfile, keyfile=keyfile)
+            try:
+                # Query the address to get back it's address family
+                addrs = socket.getaddrinfo(address[0], address[1], 0,
+                                           socket.SOCK_STREAM)
+                conn = context.wrap_socket(module.socket(addrs[0][0]))
+                conn.connect(address)
+                sock = conn
+                break
+            except ssl.SSLError:
+                raise
+        else:
+            try:
+                sock = module.create_connection(address, timeout)
+
+                # if we got a timeout, lets ensure that we decrement the time
+                # otherwise there is no timeout set and we'll call it as such
+                timeout_at = end if end is None else end - time.time()
+                sock = module.create_connection(address, timeout_at)
+                break
+            except Exception as ex:
+                errnum = ex.errno if isinstance(ex, OSError) else ex[0]
+                if errnum == errno.EINTR:
+                    continue
+                raise
 
     if sock is None:
         raise module.error

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -216,13 +216,21 @@ class ConnectionHandler(object):
         remaining = length
         with self._socket_error_handling():
             while remaining > 0:
-                s = self.handler.select([self._socket], [], [], timeout)[0]
-                if not s:  # pragma: nocover
-                    # If the read list is empty, we got a timeout. We don't
-                    # have to check wlist and xlist as we don't set any
-                    raise self.handler.timeout_exception("socket time-out"
-                                                         " during read")
-
+                # Because of SSL framing, a select may not return when using
+                # an SSL socket because the underlying physical socket may not
+                # have anything to select, but the wrapped object may still
+                # have something to read as it has previously gotten enough
+                # data from the underlying socket.
+                if (hasattr(self._socket, "pending")
+                        and self._socket.pending() > 0):
+                    pass
+                else:
+                    s = self.handler.select([self._socket], [], [], timeout)[0]
+                    if not s:  # pragma: nocover
+                        # If the read list is empty, we got a timeout. We don't
+                        # have to check wlist and xlist as we don't set any
+                        raise self.handler.timeout_exception(
+                            "socket time-out during read")
                 chunk = self._socket.recv(remaining)
                 if chunk == b'':
                     raise ConnectionDropped('socket connection broken')
@@ -596,7 +604,8 @@ class ConnectionHandler(object):
 
     def _connect(self, host, port):
         client = self.client
-        self.logger.info('Connecting to %s:%s', host, port)
+        self.logger.info('Connecting to %s:%s, use_ssl: %r',
+                         host, port, self.client.use_ssl)
 
         self.logger.log(BLATHER,
                         '    Using session_id: %r session_passwd: %s',
@@ -605,7 +614,13 @@ class ConnectionHandler(object):
 
         with self._socket_error_handling():
             self._socket = self.handler.create_connection(
-                (host, port), client._session_timeout / 1000.0)
+                address=(host, port),
+                timeout=client._session_timeout / 1000.0,
+                use_ssl=self.client.use_ssl,
+                keyfile=self.client.keyfile,
+                certfile=self.client.certfile,
+                ca=self.client.ca,
+            )
 
         self._socket.setblocking(0)
 


### PR DESCRIPTION
Zookeeper 3.5 supports SSL for client communications, this commit
adds support for it on the Kazoo side.

Note that you need to give the client the key, certificate and CA
files.

Co-Authored-By: Monty Taylor <mordred@inaugust.com>