### PR TITLE
fix(core): Correctly fire multiple callbacks

### DIFF
--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -46,7 +46,7 @@ class AsyncResult(object):
             self._exception = None
             for callback in self._callbacks:
                 self._handler.completion_queue.put(
-                    lambda: callback(self)
+                    functools.partial(callback, self)
                 )
             self._condition.notify_all()
 
@@ -56,7 +56,7 @@ class AsyncResult(object):
             self._exception = exception
             for callback in self._callbacks:
                 self._handler.completion_queue.put(
-                    lambda: callback(self)
+                    functools.partial(callback, self)
                 )
             self._condition.notify_all()
 
@@ -103,7 +103,7 @@ class AsyncResult(object):
             # Are we already set? Dispatch it now
             if self.ready():
                 self._handler.completion_queue.put(
-                    lambda: callback(self)
+                    functools.partial(callback, self)
                 )
                 return
 

--- a/kazoo/tests/test_threading_handler.py
+++ b/kazoo/tests/test_threading_handler.py
@@ -376,3 +376,19 @@ class TestThreadingAsync(unittest.TestCase):
         assert regular_function() == 'hello'
         assert mock_handler.completion_queue.put.called
         assert async_result.get() == 'hello'
+
+    def test_multiple_callbacks(self):
+        mockback1 = mock.Mock(name='mockback1')
+        mockback2 = mock.Mock(name='mockback2')
+        handler = self._makeHandler()
+        handler.start()
+
+        async_result = self._makeOne(handler)
+        async_result.rawlink(mockback1)
+        async_result.rawlink(mockback2)
+        async_result.set('howdy')
+        async_result.wait()
+        handler.stop()
+
+        mockback2.assert_called_once_with(async_result)
+        mockback1.assert_called_once_with(async_result)


### PR DESCRIPTION
Due to the use of unbound lambdas in AsyncResult, multiple callbacks
wouldn't actually get called. it would only call the final callback N
times, where N is the number of registered callbacks.