### PR TITLE
feat(tests): bump zookeper version to 3.5.4-beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,31 +19,43 @@ matrix:
   - python: '2.7'
     env: ZOOKEEPER_VERSION=3.4.13 TOX_VENV=py27
   - python: '2.7'
+    env: ZOOKEEPER_VERSION=3.5.4-beta TOX_VENV=py27
+  - python: '2.7'
     env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py27-gevent
   - python: '2.7'
     env: ZOOKEEPER_VERSION=3.4.13 TOX_VENV=py27-gevent
+  - python: '2.7'
+    env: ZOOKEEPER_VERSION=3.5.4-beta TOX_VENV=py27-gevent
   - python: '2.7'
     env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py27-eventlet
   - python: '2.7'
     env: ZOOKEEPER_VERSION=3.4.13 TOX_VENV=py27-eventlet
   - python: '2.7'
-    env: ZOOKEEPER_VERSION=3.5.2-alpha TOX_VENV=py27
+    env: ZOOKEEPER_VERSION=3.5.4-beta TOX_VENV=py27-eventlet
   - python: '3.4'
     env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py34
   - python: '3.4'
     env: ZOOKEEPER_VERSION=3.4.13 TOX_VENV=py34
+  - python: '3.4'
+    env: ZOOKEEPER_VERSION=3.5.4-beta TOX_VENV=py34
   - python: '3.5'
     env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py35
   - python: '3.5'
     env: ZOOKEEPER_VERSION=3.4.13 TOX_VENV=py35
+  - python: '3.5'
+    env: ZOOKEEPER_VERSION=3.5.4-beta TOX_VENV=py35
   - python: '3.6'
     env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=py36
   - python: '3.6'
     env: ZOOKEEPER_VERSION=3.4.13 TOX_VENV=py36
+  - python: '3.6'
+    env: ZOOKEEPER_VERSION=3.5.4-beta TOX_VENV=py36
   - python: pypy
     env: ZOOKEEPER_VERSION=3.3.6 TOX_VENV=pypy
   - python: pypy
     env: ZOOKEEPER_VERSION=3.4.13 TOX_VENV=pypy
+  - python: 'pypy'
+    env: ZOOKEEPER_VERSION=3.5.4-beta TOX_VENV=pypy
 notifications:
   email: false
 install:


### PR DESCRIPTION
I upgraded Zookeeper version to 3.5.4-beta. Some changes occured since the 3.5.2-alpha used before :

- reconfig needs to be explicitely activated in zookeeper configuration
- reconfig needs to be used with superuser
- envi command must be added to whitelist

I added a test to check that a NoAuthError is obtained when trying to use Reconfig without superuser. I corrected Reconfig's tests to use superuser auth. I modified the testing/common.py file to add the new parameters to zookeeper server.