### PR TITLE
feat(core): Added SSL support

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -108,7 +108,7 @@ class KazooClient(object):
                  randomize_hosts=True, connection_retry=None,
                  command_retry=None, logger=None, keyfile=None,
                  keyfile_password=None, certfile=None, ca=None,
-                 use_ssl=False, **kwargs):
+                 use_ssl=False, verify_certs=True, **kwargs):
         """Create a :class:`KazooClient` instance. All time arguments
         are in seconds.
 
@@ -142,6 +142,7 @@ class KazooClient(object):
         :param certfile: SSL certfile to use for authentication
         :param ca: SSL CA file to use for authentication
         :param use_ssl: argument to control whether SSL is used or not
+        :param verify_certs: when using SSL, argument to bypass certs verification
 
         Basic Example:
 
@@ -191,6 +192,7 @@ class KazooClient(object):
         self.set_hosts(hosts)
 
         self.use_ssl = use_ssl
+        self.verify_certs= verify_certs
         self.certfile = certfile
         self.keyfile = keyfile
         self.keyfile_password = keyfile_password
@@ -666,6 +668,7 @@ class KazooClient(object):
             certfile=self.certfile,
             keyfile=self.keyfile,
             keyfile_password=self.keyfile_password,
+            verify_certs=self.verify_certs,
         )
         sock.sendall(cmd)
         result = sock.recv(8192)

--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -107,7 +107,8 @@ class KazooClient(object):
                  default_acl=None, auth_data=None, read_only=None,
                  randomize_hosts=True, connection_retry=None,
                  command_retry=None, logger=None, keyfile=None,
-                 certfile=None, ca=None, use_ssl=False, **kwargs):
+                 keyfile_password=None, certfile=None, ca=None,
+                 use_ssl=False, **kwargs):
         """Create a :class:`KazooClient` instance. All time arguments
         are in seconds.
 
@@ -137,6 +138,7 @@ class KazooClient(object):
         :param logger: A custom logger to use instead of the module
             global `log` instance.
         :param keyfile: SSL keyfile to use for authentication
+        :param keyfile_password: SSL keyfile password
         :param certfile: SSL certfile to use for authentication
         :param ca: SSL CA file to use for authentication
         :param use_ssl: argument to control whether SSL is used or not
@@ -191,6 +193,7 @@ class KazooClient(object):
         self.use_ssl = use_ssl
         self.certfile = certfile
         self.keyfile = keyfile
+        self.keyfile_password = keyfile_password
         self.ca = ca
         # Curator like simplified state tracking, and listeners for
         # state transitions
@@ -662,6 +665,7 @@ class KazooClient(object):
             ca=self.ca,
             certfile=self.certfile,
             keyfile=self.keyfile,
+            keyfile_password=self.keyfile_password,
         )
         sock.sendall(cmd)
         result = sock.recv(8192)

--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -142,7 +142,8 @@ class KazooClient(object):
         :param certfile: SSL certfile to use for authentication
         :param ca: SSL CA file to use for authentication
         :param use_ssl: argument to control whether SSL is used or not
-        :param verify_certs: when using SSL, argument to bypass certs verification
+        :param verify_certs: when using SSL, argument to bypass
+            certs verification
 
         Basic Example:
 
@@ -192,7 +193,7 @@ class KazooClient(object):
         self.set_hosts(hosts)
 
         self.use_ssl = use_ssl
-        self.verify_certs= verify_certs
+        self.verify_certs = verify_certs
         self.certfile = certfile
         self.keyfile = keyfile
         self.keyfile_password = keyfile_password

--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -187,7 +187,8 @@ def create_tcp_socket(module):
 
 def create_tcp_connection(module, address, timeout=None,
                           use_ssl=False, ca=None, certfile=None,
-                          keyfile=None, keyfile_password=None):
+                          keyfile=None, keyfile_password=None,
+                          verify_certs=True):
     end = None
     if timeout is None:
         # thanks to create_connection() developers for
@@ -203,11 +204,13 @@ def create_tcp_connection(module, address, timeout=None,
             context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
             context.options |= ssl.OP_NO_SSLv2
             context.options |= ssl.OP_NO_SSLv3
-            context.verify_mode = ssl.CERT_OPTIONAL
+            # Load default CA certs
+            context.load_default_certs(ssl.Purpose.SERVER_AUTH)
+            context.verify_mode = ssl.CERT_OPTIONAL if verify_certs else ssl.CERT_NONE
             if ca:
                 context.load_verify_locations(ca)
             if certfile and keyfile:
-                context.verify_mode = ssl.CERT_REQUIRED
+                context.verify_mode = ssl.CERT_REQUIRED if verify_certs else ssl.CERT_NONE
                 context.load_cert_chain(certfile=certfile,
                                         keyfile=keyfile,
                                         password=keyfile_password)

--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -186,7 +186,8 @@ def create_tcp_socket(module):
 
 
 def create_tcp_connection(module, address, timeout=None,
-                          use_ssl=False, ca=None, certfile=None, keyfile=None):
+                          use_ssl=False, ca=None, certfile=None,
+                          keyfile=None, keyfile_password=None):
     end = None
     if timeout is None:
         # thanks to create_connection() developers for
@@ -207,7 +208,9 @@ def create_tcp_connection(module, address, timeout=None,
                 context.load_verify_locations(ca)
             if certfile and keyfile:
                 context.verify_mode = ssl.CERT_REQUIRED
-                context.load_cert_chain(certfile=certfile, keyfile=keyfile)
+                context.load_cert_chain(certfile=certfile,
+                                        keyfile=keyfile,
+                                        password=keyfile_password)
             try:
                 # Query the address to get back it's address family
                 addrs = socket.getaddrinfo(address[0], address[1], 0,
@@ -220,8 +223,6 @@ def create_tcp_connection(module, address, timeout=None,
                 raise
         else:
             try:
-                sock = module.create_connection(address, timeout)
-
                 # if we got a timeout, lets ensure that we decrement the time
                 # otherwise there is no timeout set and we'll call it as such
                 timeout_at = end if end is None else end - time.time()

--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -3,6 +3,8 @@
 import errno
 import functools
 import select
+import ssl
+import socket
 import time
 
 HAS_FNCTL = True
@@ -183,7 +185,8 @@ def create_tcp_socket(module):
     return sock
 
 
-def create_tcp_connection(module, address, timeout=None):
+def create_tcp_connection(module, address, timeout=None,
+                          use_ssl=False, ca=None, certfile=None, keyfile=None):
     end = None
     if timeout is None:
         # thanks to create_connection() developers for
@@ -194,17 +197,41 @@ def create_tcp_connection(module, address, timeout=None):
     sock = None
 
     while end is None or time.time() < end:
-        try:
-            # if we got a timeout, lets ensure that we decrement the time
-            # otherwise there is no timeout set and we'll call it as such
-            timeout_at = end if end is None else end - time.time()
-            sock = module.create_connection(address, timeout_at)
-            break
-        except Exception as ex:
-            errnum = ex.errno if isinstance(ex, OSError) else ex[0]
-            if errnum == errno.EINTR:
-                continue
-            raise
+        if use_ssl:
+            # Disallow use of SSLv2 and V3 (meaning we require TLSv1.0+)
+            context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+            context.options |= ssl.OP_NO_SSLv2
+            context.options |= ssl.OP_NO_SSLv3
+            context.verify_mode = ssl.CERT_OPTIONAL
+            if ca:
+                context.load_verify_locations(ca)
+            if certfile and keyfile:
+                context.verify_mode = ssl.CERT_REQUIRED
+                context.load_cert_chain(certfile=certfile, keyfile=keyfile)
+            try:
+                # Query the address to get back it's address family
+                addrs = socket.getaddrinfo(address[0], address[1], 0,
+                                           socket.SOCK_STREAM)
+                conn = context.wrap_socket(module.socket(addrs[0][0]))
+                conn.connect(address)
+                sock = conn
+                break
+            except ssl.SSLError:
+                raise
+        else:
+            try:
+                sock = module.create_connection(address, timeout)
+
+                # if we got a timeout, lets ensure that we decrement the time
+                # otherwise there is no timeout set and we'll call it as such
+                timeout_at = end if end is None else end - time.time()
+                sock = module.create_connection(address, timeout_at)
+                break
+            except Exception as ex:
+                errnum = ex.errno if isinstance(ex, OSError) else ex[0]
+                if errnum == errno.EINTR:
+                    continue
+                raise
 
     if sock is None:
         raise module.error

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -620,6 +620,7 @@ class ConnectionHandler(object):
                 keyfile=self.client.keyfile,
                 certfile=self.client.certfile,
                 ca=self.client.ca,
+                keyfile_password=self.client.keyfile_password,
             )
 
         self._socket.setblocking(0)

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -621,6 +621,7 @@ class ConnectionHandler(object):
                 certfile=self.client.certfile,
                 ca=self.client.ca,
                 keyfile_password=self.client.keyfile_password,
+                verify_certs=self.client.verify_certs,
             )
 
         self._socket.setblocking(0)

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -216,13 +216,21 @@ class ConnectionHandler(object):
         remaining = length
         with self._socket_error_handling():
             while remaining > 0:
-                s = self.handler.select([self._socket], [], [], timeout)[0]
-                if not s:  # pragma: nocover
-                    # If the read list is empty, we got a timeout. We don't
-                    # have to check wlist and xlist as we don't set any
-                    raise self.handler.timeout_exception("socket time-out"
-                                                         " during read")
-
+                # Because of SSL framing, a select may not return when using
+                # an SSL socket because the underlying physical socket may not
+                # have anything to select, but the wrapped object may still
+                # have something to read as it has previously gotten enough
+                # data from the underlying socket.
+                if (hasattr(self._socket, "pending")
+                        and self._socket.pending() > 0):
+                    pass
+                else:
+                    s = self.handler.select([self._socket], [], [], timeout)[0]
+                    if not s:  # pragma: nocover
+                        # If the read list is empty, we got a timeout. We don't
+                        # have to check wlist and xlist as we don't set any
+                        raise self.handler.timeout_exception(
+                            "socket time-out during read")
                 chunk = self._socket.recv(remaining)
                 if chunk == b'':
                     raise ConnectionDropped('socket connection broken')
@@ -596,7 +604,8 @@ class ConnectionHandler(object):
 
     def _connect(self, host, port):
         client = self.client
-        self.logger.info('Connecting to %s:%s', host, port)
+        self.logger.info('Connecting to %s:%s, use_ssl: %r',
+                         host, port, self.client.use_ssl)
 
         self.logger.log(BLATHER,
                         '    Using session_id: %r session_passwd: %s',
@@ -605,7 +614,13 @@ class ConnectionHandler(object):
 
         with self._socket_error_handling():
             self._socket = self.handler.create_connection(
-                (host, port), client._session_timeout / 1000.0)
+                address=(host, port),
+                timeout=client._session_timeout / 1000.0,
+                use_ssl=self.client.use_ssl,
+                keyfile=self.client.keyfile,
+                certfile=self.client.certfile,
+                ca=self.client.ca,
+            )
 
         self._socket.setblocking(0)
 


### PR DESCRIPTION
This PR adds SSL support for Zookeeper connection. I took back the commit from https://github.com/python-zk/kazoo/pull/494

Usage is:
```
from kazoo.client import KazooClient
zk = KazooClient(hosts='172.20.0.2:2281', use_ssl=True, keyfile='/path/to/key.pem', certfile='/path/to/cert.pem', ca='/path/to/ca.pem', keyfile_password='password')
zk.start()
...
```
When playing with self signed certificate, it is possible to bypass certs verification using the paramater 'verify_certs':
```
from kazoo.client import KazooClient
zk = KazooClient(hosts='172.20.0.2:2281', use_ssl=True, keyfile='/path/to/key.pem', certfile='/path/to/cert.pem', keyfile_password='password', verify_certs=False)
zk.start()
...
```
I am not sure on how to add tests since I need to add a specific SSL configuration for only these tests and that I may need to dynamically generate certificates and keystore / truststore. I would be grateful if I can get some hints on how to add those tests.

Stephen