### PR TITLE
fix(core): negative timeouts should not be generated

### DIFF
--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -199,7 +199,11 @@ def create_tcp_connection(module, address, timeout=None,
     sock = None
 
     while end is None or time.time() < end:
-        timeout_at = end if end is None else end - time.time()
+        # max() is used to handle a weird edge case where timeout_at
+        # was being set to a negative number. 0.0001 was arbitrarily
+        # picked as a small non-zero number. more info here:
+        # https://github.com/python-zk/kazoo/pull/518
+        timeout_at = end if end is None else max(end - time.time(), 0.0001)
         if use_ssl:
             # Disallow use of SSLv2 and V3 (meaning we require TLSv1.0+)
             context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)


### PR DESCRIPTION
Encountered a strange situation where `timeout_at` was set to a negative value.  This caused python sock.settimeout() to throw ValueError('Timeout value out of range',)

The probably-overly-broad `try...except` below couldn't handle the ValueError that was thrown as a result. Thus a TypeError("'ValueError' object is not subscriptable") was thrown.

Dump of variables at the moment the when exception occurred:

```
timeout_at	-6.888538122177124
sock	    None
end	        1532524647.0125406
timeout     10.0
address	    ('10.0.100.82', 2181)
module	    <module 'socket' from '/usr/local/lib/python3.6/socket.py'>
```

This would seem to imply that somehow ~16.8 seconds elapsed between `end` getting set and timeout_at being calculated. Probably a weird edge case.

One other thing, reading the python socket settimeout docs, its wasn't clear to me if the behavior of settimeout(0.0) was to immediately timeout or to have no timeout.  Thus I set it to an _almost_ immediate timeout value.