### PR TITLE
KazooRetry: Do uniform jitter over the whole backoff interval

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -79,7 +79,6 @@ _RETRY_COMPAT_DEFAULTS = dict(
     max_retries=None,
     retry_delay=0.1,
     retry_backoff=2,
-    retry_jitter=0.8,
     retry_max_delay=3600,
 )
 
@@ -87,7 +86,6 @@ _RETRY_COMPAT_MAPPING = dict(
     max_retries='max_tries',
     retry_delay='delay',
     retry_backoff='backoff',
-    retry_jitter='max_jitter',
     retry_max_delay='max_delay',
 )
 


### PR DESCRIPTION
The previous implementation would add a fixed amount of jitter around
the calculated back-off time. Retry attempts were thus clustered
around the exponentially spaced backoff points.

This patch does exponential backoff but uniformly spreads the retries
over an interval [0, backoff**attempt]

The following graphs show the connection rate/s when trying to open 20k new connections
to ZK. Each client was configured with, backoff=2, delay=10 and max_delay=180. The ZK in question is rate-limited and that explains the ceiling you see on the second graph. 

**Old Jitter**
The connections attempts come in herds after the current delay interval has passed.
After over 30mins only about 10k connections had been established and that is where I cut-off the graph.

![zk_connections_no_jitter](https://user-images.githubusercontent.com/1608043/45300553-f6d31b80-b50e-11e8-9080-3648504853fb.png)


**Uniform Jitter**
The connection attempts reach the rate-limit then after 8 minutes the connection rate
falls below the limit and the remaining clients connect over a period of 5 mins. The whole
process takes 13 minutes.

![zk_connections_patched](https://user-images.githubusercontent.com/1608043/45300716-6812ce80-b50f-11e8-8630-04bfa98f9a1d.png)
