### PR TITLE
fix(recipe): No more memory leak once TreeCache was closed

### DIFF
--- a/kazoo/handlers/eventlet.py
+++ b/kazoo/handlers/eventlet.py
@@ -107,6 +107,8 @@ class SequentialEventletHandler(object):
             except Exception:
                 LOG.warning("Exception in worker completion queue greenlet",
                             exc_info=True)
+            finally:
+                del cb  # release before possible idle
 
     def _process_callback_queue(self):
         while True:
@@ -119,6 +121,8 @@ class SequentialEventletHandler(object):
             except Exception:
                 LOG.warning("Exception in worker callback queue greenlet",
                             exc_info=True)
+            finally:
+                del cb  # release before possible idle
 
     def start(self):
         if not self._started:

--- a/kazoo/handlers/gevent.py
+++ b/kazoo/handlers/gevent.py
@@ -69,14 +69,17 @@ class SequentialGeventHandler(object):
             while True:
                 try:
                     func = queue.get()
-                    if func is _STOP:
-                        break
-                    func()
+                    try:
+                        if func is _STOP:
+                            break
+                        func()
+                    except Exception as exc:
+                        log.warning("Exception in worker greenlet")
+                        log.exception(exc)
+                    finally:
+                        del func  # release before possible idle
                 except self.queue_empty:
                     continue
-                except Exception as exc:
-                    log.warning("Exception in worker greenlet")
-                    log.exception(exc)
         return gevent.spawn(greenlet_worker)
 
     def start(self):

--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -126,6 +126,7 @@ class SequentialThreadingHandler(object):
                         log.exception("Exception in worker queue thread")
                     finally:
                         queue.task_done()
+                        del func  # release before possible idle
                 except self.queue_empty:
                     continue
         t = self.spawn(_thread_worker)

--- a/kazoo/recipe/cache.py
+++ b/kazoo/recipe/cache.py
@@ -58,6 +58,12 @@ class TreeCache(object):
         After a cache started, all changes of subtree will be synchronized
         from the ZooKeeper server. Events will be fired for those activity.
 
+        Don't forget to call :meth:`close` if a tree was started and you don't
+        need it anymore, or you will leak the memory of cached nodes, even if
+        you have released all references to the :class:`TreeCache` instance.
+        Because there are so many callbacks that have been registered to the
+        Kazoo client.
+
         See also :meth:`~TreeCache.listen`.
 
         .. note::

--- a/kazoo/recipe/cache.py
+++ b/kazoo/recipe/cache.py
@@ -186,6 +186,9 @@ class TreeCache(object):
                 func, args, kwargs = cb
                 func(*args, **kwargs)
 
+                # release before possible idle
+                del cb, func, args, kwargs
+
     def _session_watcher(self, state):
         if state == KazooState.SUSPENDED:
             self._publish_event(TreeEvent.CONNECTION_SUSPENDED)

--- a/kazoo/recipe/cache.py
+++ b/kazoo/recipe/cache.py
@@ -404,10 +404,11 @@ def handle_exception(listeners):
         yield
     except Exception as e:
         logger.debug('processing error: %r', e)
-        for listener in listeners:
-            try:
-                listener(e)
-            except BaseException:  # pragma: no cover
-                logger.exception('Exception handling exception')  # oops
+        if listeners:
+            for listener in listeners:
+                try:
+                    listener(e)
+                except BaseException:  # pragma: no cover
+                    logger.exception('Exception handling exception')  # oops
         else:
             logger.exception('No listener to process %r', e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mock==1.0.1
 nose==1.3.3
 pure-sasl==0.5.1
 flake8==2.3.0
+objgraph==3.4.0

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ tests_require = install_requires + [
     'nose',
     'flake8',
     'pure-sasl',
+    'objgraph',
 ]
 
 if not (PYTHON3 or PYPY):


### PR DESCRIPTION
The current implementation of TreeCache recipe could not be closed completely because some unexpected references:

1. The registered znode event watchers hold the reference of instancemethod which are bound with `TreeNode` instances
2. The background threads in connection handler keep last reference when they are idle

This pull request fixes those memory leak problems, and verifies that by using `objgraph` in test.

We could guarantee all closed `TreeCache` will be eventually released now. (not immediately since the cycle reference between `TreeNode` and `TreeCache` must be resolved by mark-swap GC of Python)