### PR TITLE
docs: remove broken downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Kazoo
 
 ![Latest Version](https://img.shields.io/pypi/v/kazoo.svg)
 
-![Downloads](https://img.shields.io/pypi/dm/kazoo.svg)
-
 `kazoo` implements a higher level API to [Apache
 Zookeeper](http://zookeeper.apache.org/) for Python clients.
 


### PR DESCRIPTION
Pypi quit offering download stats, so remove this broken badge.