### PR TITLE
docs: make badges link to travis and pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Kazoo
 =====
 
-![Travis Build](https://travis-ci.org/python-zk/kazoo.svg?branch=master)
+[![Build Status](https://travis-ci.org/python-zk/kazoo.svg?branch=master)](https://travis-ci.org/python-zk/kazoo)
 
-![Latest Version](https://img.shields.io/pypi/v/kazoo.svg)
+[![PyPI version](https://badge.fury.io/py/kazoo.svg)](https://badge.fury.io/py/kazoo)
 
 `kazoo` implements a higher level API to [Apache
 Zookeeper](http://zookeeper.apache.org/) for Python clients.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Kazoo
 
 [![Build Status](https://travis-ci.org/python-zk/kazoo.svg?branch=master)](https://travis-ci.org/python-zk/kazoo)
 
-[![PyPI version](https://badge.fury.io/py/kazoo.svg)](https://badge.fury.io/py/kazoo)
+[![Latest Version](https://img.shields.io/pypi/v/kazoo.svg)](https://pypi.org/project/kazoo/)
 
 `kazoo` implements a higher level API to [Apache
 Zookeeper](http://zookeeper.apache.org/) for Python clients.


### PR DESCRIPTION
Currently the badges just open a static image of the badges. This makes it so that it opens the actual links to latest travis build and PyPi instead.

[Updated README](https://github.com/python-zk/kazoo/blob/0dfa2670393c6878896bab630825664704c9efe8/README.md).

For context: https://docs.travis-ci.com/user/status-images/ this is where I got the Travis link button command. 
And https://badge.fury.io/for/py/kazoo for the PyPi badge.


**Update**: Moved to using shields.io like it was before instead of badge.fury. Here's the [README](https://github.com/python-zk/kazoo/blob/c79a152668e166321d849aa3ed749264f3eb1b29/README.md) with shields.io.