### PR TITLE
docs: specify description type for pypi to render correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -217,9 +217,9 @@ VERSIONS WILL REQUIRE PYTHON 2.7 AND ABOVE.
 
 -   Logging levels have been reduced.
     -   Logging previously at the `logging.DEBUG` level is now logged at
-        the `kazoo.loggingsupport.BLATHER` level (5).
+    the `kazoo.loggingsupport.BLATHER` level (5).
     -   Some low-level logging previously at the `logging.INFO` level is
-        now logged at the `logging.DEBUG` level.
+    now logged at the `logging.DEBUG` level.
 -   Issue \#133: Introduce a new environment variable
     ZOOKEEPER\_PORT\_OFFSET for the testing support, to run the testing
     cluster on a different range.

--- a/setup.py
+++ b/setup.py
@@ -77,4 +77,5 @@ setup(
     extras_require={
         'test': tests_require,
     },
+    long_description_content_type="text/markdown",
 )


### PR DESCRIPTION
While working on https://github.com/python-zk/kazoo/pull/528, I realized that the docs don't actually render correctly on [PyPi](https://pypi.org/project/kazoo/2.5.0/). This is because PyPi defaults to assuming a `.rst` file ( as specified in the [FAQs](https://pypi.org/help/#description-content-type)) and our readme is `.md`

PyPi pointed to the [python packaging guide](https://packaging.python.org/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata) which explains to include the `long_description_content_type="text/markdown",` parameter in your setup for proper packaging. On testing with `twine` as specified in the python packaging guide, I got an error `Unexpected indentation line 270` which was fixed by unindenting the two lines below. 

Steps to test the docs are:
* `$ python setup.py sdist`
* `$ twine check dist/*`

Sorry for all the links but hope this makes sense!