### PR TITLE
Add "Reviewed by Hound" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Kazoo
 =====
 
 [![Build Status](https://travis-ci.org/python-zk/kazoo.svg?branch=master)](https://travis-ci.org/python-zk/kazoo)
-
 [![Latest Version](https://img.shields.io/pypi/v/kazoo.svg)](https://pypi.org/project/kazoo/)
+[![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 
 `kazoo` implements a higher level API to [Apache
 Zookeeper](http://zookeeper.apache.org/) for Python clients.


### PR DESCRIPTION
<img width="659" alt="screenshot 2018-10-22 08 27 03" src="https://user-images.githubusercontent.com/154463/47301679-4d367e00-d5d4-11e8-8d65-fb06eadc35b5.png">

It looks like there are duplicate status updates for Hound. The capitalized one is the correct update. You should be able to [turn off branch protection](https://github.com/python-zk/kazoo/settings/branches) for `hound` to fix that.