### PR TITLE
Fix start_async deadlock when called twice in a row

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -598,6 +598,7 @@ class KazooClient(object):
             return self._live
 
         # Make sure we're safely closed
+        self._stopped.set()
         self._safe_close()
 
         # We've been asked to connect, clear the stop and our writer


### PR DESCRIPTION
Fix https://github.com/python-zk/kazoo/issues/536.

Not entirely sure how it works. Doesn't seem to do any harm anyways.