### PR TITLE
Reduce timeout for the first Connect() request

### DIFF
--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -660,7 +660,7 @@ class ConnectionHandler(object):
                           client.read_only)
 
         connect_result, zxid = self._invoke(
-            client._session_timeout / 1000.0, connect)
+            client._session_timeout / 1000.0 / len(client.hosts), connect)
 
         if connect_result.time_out <= 0:
             raise SessionExpiredError("Session has expired")


### PR DESCRIPTION
In the case of a zookeeper server under pressure, it will typically try to maintain the quorum rather than handling client requests. In this kind of case, the quorum is maintained, the connection works, but the client is frozen there.

Retrying after a shorter timeout means we can reconnect to another server before losing the session altogether.