### PR TITLE
fix(recipe):No more memory leak when ChildrenWatch was stopped

### DIFF
--- a/kazoo/recipe/watchers.py
+++ b/kazoo/recipe/watchers.py
@@ -341,6 +341,8 @@ class ChildrenWatch(object):
                 if result is False:
                     self._stopped = True
                     self._func = None
+                    if self._allow_session_lost:
+                        self._client.remove_listener(self._session_watcher)
             except Exception as exc:
                 log.exception(exc)
                 raise

--- a/kazoo/tests/test_watchers.py
+++ b/kazoo/tests/test_watchers.py
@@ -432,7 +432,8 @@ class KazooChildrenWatcherTests(KazooTestCase):
             if fail_through:
                 return False
 
-        session_watcher = self.client.ChildrenWatch(self.path, changed)._session_watcher
+        childrenWatch = self.client.ChildrenWatch(self.path, changed)
+        session_watcher = childrenWatch._session_watcher
 
         update.wait(10)
         eq_(session_watcher in self.client.state_listeners, True)

--- a/kazoo/tests/test_watchers.py
+++ b/kazoo/tests/test_watchers.py
@@ -418,7 +418,7 @@ class KazooChildrenWatcherTests(KazooTestCase):
         update.wait(0.5)
         eq_(all_children, ['smith'])
 
-    def test_remove_session_watcher_on_func_stops(self):
+    def test_child_watcher_remove_session_watcher(self):
         update = threading.Event()
         all_children = ['fred']
 
@@ -432,8 +432,8 @@ class KazooChildrenWatcherTests(KazooTestCase):
             if fail_through:
                 return False
 
-        childrenWatch = self.client.ChildrenWatch(self.path, changed)
-        session_watcher = childrenWatch._session_watcher
+        children_watch = self.client.ChildrenWatch(self.path, changed)
+        session_watcher = children_watch._session_watcher
 
         update.wait(10)
         eq_(session_watcher in self.client.state_listeners, True)
@@ -448,7 +448,7 @@ class KazooChildrenWatcherTests(KazooTestCase):
         update.clear()
 
         self.client.create(self.path + '/' + 'george')
-        update.wait(0.5)
+        update.wait(10)
         eq_(session_watcher not in self.client.state_listeners, True)
         eq_(all_children, ['smith'])
 


### PR DESCRIPTION
Remove session watcher from the listener when ChildrenWatch was stopped