### PR TITLE
fix(handlers): make AsyncResult call all registered callbacks instantly if the handler has stopped running

### DIFF
--- a/kazoo/handlers/gevent.py
+++ b/kazoo/handlers/gevent.py
@@ -60,6 +60,10 @@ class SequentialGeventHandler(object):
         self._state_change = Semaphore()
         self._workers = []
 
+    @property
+    def running(self):
+        return self._running
+
     class timeout_exception(gevent.Timeout):
         def __init__(self, msg):
             gevent.Timeout.__init__(self, exception=msg)

--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -113,6 +113,10 @@ class SequentialThreadingHandler(object):
         self._state_change = threading.Lock()
         self._workers = []
 
+    @property
+    def running(self):
+        return self._running
+
     def _create_thread_worker(self, queue):
         def _thread_worker():  # pragma: nocover
             while True:

--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -114,17 +114,17 @@ class AsyncResult(object):
                 self._callbacks.remove(callback)
 
     def _do_callbacks(self):
-        leftovers = set()
+        """Execute the callbacks that were registered by :meth:`rawlink`.
+        If the handler is in running state this method only schedules
+        the calls to be performed by the handler. If it's stopped,
+        the callbacks are called right away."""
 
         for callback in self._callbacks:
             if self._handler.running:
                 self._handler.completion_queue.put(
                     functools.partial(callback, self))
             else:
-                leftovers.add(functools.partial(callback, self))
-
-        for cb in leftovers:
-            cb()
+                functools.partial(callback, self)()
 
 def _set_fd_cloexec(fd):
     flags = fcntl.fcntl(fd, fcntl.F_GETFD)

--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -46,20 +46,14 @@ class AsyncResult(object):
         with self._condition:
             self.value = value
             self._exception = None
-            for callback in self._callbacks:
-                self._handler.completion_queue.put(
-                    functools.partial(callback, self)
-                )
+            self._do_callbacks()
             self._condition.notify_all()
 
     def set_exception(self, exception):
         """Store the exception. Wake up the waiters."""
         with self._condition:
             self._exception = exception
-            for callback in self._callbacks:
-                self._handler.completion_queue.put(
-                    functools.partial(callback, self)
-                )
+            self._do_callbacks()
             self._condition.notify_all()
 
     def get(self, block=True, timeout=None):
@@ -102,15 +96,12 @@ class AsyncResult(object):
         """Register a callback to call when a value or an exception is
         set"""
         with self._condition:
-            # Are we already set? Dispatch it now
-            if self.ready():
-                self._handler.completion_queue.put(
-                    functools.partial(callback, self)
-                )
-                return
-
             if callback not in self._callbacks:
                 self._callbacks.append(callback)
+
+            # Are we already set? Dispatch it now
+            if self.ready():
+                self._do_callbacks()
 
     def unlink(self, callback):
         """Remove the callback set by :meth:`rawlink`"""
@@ -122,6 +113,18 @@ class AsyncResult(object):
             if callback in self._callbacks:
                 self._callbacks.remove(callback)
 
+    def _do_callbacks(self):
+        leftovers = set()
+
+        for callback in self._callbacks:
+            if self._handler.running:
+                self._handler.completion_queue.put(
+                    functools.partial(callback, self))
+            else:
+                leftovers.add(functools.partial(callback, self))
+
+        for cb in leftovers:
+            cb()
 
 def _set_fd_cloexec(fd):
     flags = fcntl.fcntl(fd, fcntl.F_GETFD)


### PR DESCRIPTION
Hi!

I'm using kazoo in a work-related project and sometimes our tests are leaving zombie threads that are blocked in `self._condition.wait(timeout)` from `AsyncResult:get`. 

After some digging it looks like the problem occurs when we start a KazooClient, try to make an operation on it like a path creation and then stop it fast. In this case, the callbacks of the `AsyncResult` may not be called if `AsyncResult:set`/`AsyncResult:set_exception` are called just after the client is stopped. As I said it might not happen too often for most people but for us it's like in 10% of the test runs and it's slows  down our development pipeline. I've made a custom `AyncResult` class in our project that modifies a bit the behavior and seems to fix the issue for us but maybe you guys would also consider this solution for the official version.

If you have other suggestions or concerns let me know.