### PR TITLE
fix(recipe): crash if None in znode

### DIFF
--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -353,7 +353,8 @@ class Lock(object):
         for child in children:
             try:
                 data, stat = self.client.get(self.path + "/" + child)
-                contenders.append(data.decode('utf-8'))
+                if data is not None:
+                    contenders.append(data.decode('utf-8'))
             except NoNodeError:  # pragma: nocover
                 pass
         return contenders


### PR DESCRIPTION
fix if znode is None
```
  File "/home/tests/kazoo/recipe/lock.py", line 341, in contenders
    contenders.append(data.decode('utf-8'))
AttributeError: 'NoneType' object has no attribute 'decode'
```
