### PR TITLE
Fix bug where kazoo client returns SESSION EXPIRED when in CONNECTING state

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -595,9 +595,11 @@ class KazooClient(object):
             async_object.set_exception(ConnectionClosedError(
                 "Connection has been closed"))
             return False
-        elif self._state in (KeeperState.EXPIRED_SESSION,
-                             KeeperState.CONNECTING):
+        elif self._state == KeeperState.EXPIRED_SESSION:
             async_object.set_exception(SessionExpiredError())
+            return False
+        elif self._state == KeeperState.CONNECTING:
+            async_object.set_exception(ConnectionLoss())
             return False
 
         self._queue.append((request, async_object))

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -593,7 +593,7 @@ class TestClient(KazooTestCase):
                           '/closedpath', b'bar')
 
         client._state = KeeperState.CONNECTING
-        self.assertRaises(SessionExpiredError, client.create,
+        self.assertRaises(ConnectionLoss, client.create,
                           '/closedpath', b'bar')
         client.stop()
         client.close()


### PR DESCRIPTION
kazoo client returns a SessionExpired when its state is in CONNECTING. This is not an indication of session expiry and could just be that the client is still re-establishing a connection to the server after a network blip. Hence, the error returned should be a ConnectionLoss and not a SessionExpired