### PR TITLE
fix(core): when connection fails, close the ConnectionHandler (#577)

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -628,6 +628,7 @@ class KazooClient(object):
         if not self.connected:
             # We time-out, ensure we are disconnected
             self.stop()
+            self.close()
             raise self.handler.timeout_exception("Connection time-out")
 
         if self.chroot and not self.exists("/"):


### PR DESCRIPTION
When connection attempts fail repeatedly (e.g. all ZK servers are
unavailable), eventually the socketpair in the ConnectionHandler fills
up, and the Client gets stuck trying to write a single byte to the
socketpair.

Avoid this by ensuring we close the socketpair on a failed connection
attempt.