### PR TITLE
WIP fix(core): allow requests to be queued in CONNECTING state (#374)

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -584,7 +584,7 @@ class KazooClient(object):
         the queue if there is.
 
         Returns False if the call short circuits due to AUTH_FAILED,
-        CLOSED, EXPIRED_SESSION or CONNECTING state.
+        CLOSED, or EXPIRED_SESSION state.
 
         """
 
@@ -595,8 +595,7 @@ class KazooClient(object):
             async_object.set_exception(ConnectionClosedError(
                 "Connection has been closed"))
             return False
-        elif self._state in (KeeperState.EXPIRED_SESSION,
-                             KeeperState.CONNECTING):
+        elif self._state == KeeperState.EXPIRED_SESSION:
             async_object.set_exception(SessionExpiredError())
             return False
 

--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -561,13 +561,14 @@ class KazooClient(object):
             except IndexError:
                 break
 
-        while True:
-            try:
-                request, async_object = self._queue.popleft()
-                if async_object:
-                    async_object.set_exception(exc)
-            except IndexError:
-                break
+        if state != KeeperState.CONNECTING:
+            while True:
+                try:
+                    request, async_object = self._queue.popleft()
+                    if async_object:
+                        async_object.set_exception(exc)
+                except IndexError:
+                    break
 
     def _safe_close(self):
         self.handler.stop()


### PR DESCRIPTION
As discussed in https://github.com/python-zk/kazoo/pull/570#issuecomment-554798550:

With this patch, requests issued while the client is in the `CONNECTING` state get queued instead of raising a (misleading) `SessionExpiredError`.

TBD:

* [X] This patch does not prevent requests which have been queued but not emitted from being rejected with `ConnectionLoss`.  It should also get rid of the second part of `_notify_pending`, shouldn't it? [Not doing this, as the C/Java clients do not, either.] 

* [x] This patch does not try to limit the maximum queue length, which should probably be controlled via a new `KazooClient` parameter.  (How about `max_queue_length`?  What should it default to?  Which exception should we raise when the queue overflows?) [Not doing this, as the C/Java clients do not, either.] 