### PR TITLE
fix(tests): specify -Dfile.encoding=UTF-8 when starting the ZK JVM

### DIFF
--- a/kazoo/security.py
+++ b/kazoo/security.py
@@ -59,7 +59,17 @@ READ_ACL_UNSAFE = [ACL(Permissions.READ, ANYONE_ID_UNSAFE)]
 
 
 def make_digest_acl_credential(username, password):
-    """Create a SHA1 digest credential"""
+    """Create a SHA1 digest credential.
+
+    .. note::
+
+        This function uses UTF-8 to encode non-ASCII codepoints,
+        whereas ZooKeeper uses the "default locale" for decoding.  It
+        may be a good idea to start the JVM with `-Dfile.encoding=UTF-8`
+        in non-UTF-8 locales.
+        See: https://github.com/python-zk/kazoo/pull/584
+
+    """
     credential = username.encode('utf-8') + b":" + password.encode('utf-8')
     cred_hash = b64encode(hashlib.sha1(credential).digest()).strip()
     return username + ":" + cred_hash.decode('utf-8')

--- a/kazoo/testing/common.py
+++ b/kazoo/testing/common.py
@@ -169,6 +169,12 @@ log4j.appender.ROLLINGFILE.File=""" + to_java_compatible_path(  # NOQA
             "java",
             "-cp", self.classpath,
 
+            # make_digest_acl_credential assumes UTF-8, but ZK decodes
+            # digest auth packets using the JVM's default "charset"--which
+            # depends on the environment.  Force it to use UTF-8 to avoid
+            # test failures.
+            "-Dfile.encoding=UTF-8",
+
             # "-Dlog4j.debug",
             "-Dreadonlymode.enabled=true",
             "-Dzookeeper.log.dir=%s" % log_path,


### PR DESCRIPTION
`make_digest_acl_credential` assumes `UTF-8`, but ZooKeeper decodes digest auth packets using the JVM's default "charset"—which depends on the environment (e.g., `ISO-8859-1` if no locale is present).

This patch defines the system property which makes the JVM hosting ZooKeeper default to `UTF-8`, independently of the locale.