### PR TITLE
feat(core): Add create2 support

### DIFF
--- a/kazoo/protocol/serialization.py
+++ b/kazoo/protocol/serialization.py
@@ -351,6 +351,27 @@ class Transaction(namedtuple('Transaction', 'operations')):
         return resp
 
 
+class Create2(namedtuple('Create2', 'path data acl flags')):
+    type = 15
+
+    def serialize(self):
+        b = bytearray()
+        b.extend(write_string(self.path))
+        b.extend(write_buffer(self.data))
+        b.extend(int_struct.pack(len(self.acl)))
+        for acl in self.acl:
+            b.extend(int_struct.pack(acl.perms) +
+                     write_string(acl.id.scheme) + write_string(acl.id.id))
+        b.extend(int_struct.pack(self.flags))
+        return b
+
+    @classmethod
+    def deserialize(cls, bytes, offset):
+        path, offset = read_string(bytes, offset)
+        stat = ZnodeStat._make(stat_struct.unpack_from(bytes, offset))
+        return path, stat
+
+
 class Reconfig(namedtuple('Reconfig',
                           'joining leaving new_members config_id')):
     type = 16


### PR DESCRIPTION
Add support for `Create2` opcode (create returns ZkStat along side the path after a successful node creation).