### PR TITLE
fix(core): allow requests to be queued in CONNECTING state (#374) [v2]

### DIFF
--- a/docs/api/client.rst
+++ b/docs/api/client.rst
@@ -30,6 +30,27 @@ Public API
             A :class:`~kazoo.protocol.states.KazooState` attribute indicating
             the current higher-level connection state.
 
+            .. note::
+
+                Up to version 2.6.1, requests could only be submitted
+                in the CONNECTED state.  Requests submitted while
+                SUSPENDED would immediately raise a
+                :exc:`~kazoo.exceptions.SessionExpiredError`.  This
+                was problematic, as sessions are usually recovered on
+                reconnect.
+
+                Kazoo now simply queues requests submitted in the
+                SUSPENDED state, expecting a recovery.  This matches
+                the behavior of the Java and C clients.
+
+                Requests submitted in a LOST state still fail
+                immediately with the corresponding exception.
+
+                See:
+
+                  * https://github.com/python-zk/kazoo/issues/374 and
+                  * https://github.com/python-zk/kazoo/pull/570
+
     .. autoclass:: TransactionRequest
         :members:
         :member-order: bysource

--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -584,11 +584,11 @@ class KazooClient(object):
                 "and wouldn't close after %s seconds" % timeout)
 
     def _call(self, request, async_object):
-        """Ensure there's an active connection and put the request in
-        the queue if there is.
+        """Ensure the client is in CONNECTED or SUSPENDED state and put the
+        request in the queue if it is.
 
         Returns False if the call short circuits due to AUTH_FAILED,
-        CLOSED, EXPIRED_SESSION or CONNECTING state.
+        CLOSED, or EXPIRED_SESSION state.
 
         """
 
@@ -599,8 +599,7 @@ class KazooClient(object):
             async_object.set_exception(ConnectionClosedError(
                 "Connection has been closed"))
             return False
-        elif self._state in (KeeperState.EXPIRED_SESSION,
-                             KeeperState.CONNECTING):
+        elif self._state == KeeperState.EXPIRED_SESSION:
             async_object.set_exception(SessionExpiredError())
             return False
 


### PR DESCRIPTION
With this patch, requests issued while the client is in the `CONNECTING` state get queued instead of raising a misleading `SessionExpiredError`.

This fixes https://github.com/python-zk/kazoo/issues/374, and brings Kazoo more in line with the Java and C clients.

See the `kazoo.client.KazooClient.state` documentation as well as these discussions for more details:

  * https://github.com/python-zk/kazoo/pull/570#issuecomment-554798550
  * https://github.com/python-zk/kazoo/pull/583#issuecomment-586422386

This "v2" is a respin of https://github.com/python-zk/kazoo/pull/583 which only includes the fix for https://github.com/python-zk/kazoo/issues/374.

A few notes:

 - [X] Fixes the issue, and passes existing/adapted/new tests;
 - [X] The aforementioned queue is unbounded, but that matches the Java/C clients;
 - [X] The queue is emptied if the client leaves the `CONNECTING` state;
 - [X] The change in behavior is mentioned in the client documentation.

(Feel free to suggest a better place for that documentation.  I haven't updated `CHANGES.md` as that seems to be done at release time.)