### PR TITLE
feat(core): Add support for Create2 in transactions.

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -1590,7 +1590,7 @@ class TransactionRequest(object):
         self.committed = False
 
     def create(self, path, value=b"", acl=None, ephemeral=False,
-               sequence=False):
+               sequence=False, include_data=False):
         """Add a create ZNode to the transaction. Takes the same
         arguments as :meth:`KazooClient.create`, with the exception
         of `makepath`.
@@ -1612,6 +1612,8 @@ class TransactionRequest(object):
             raise TypeError("Invalid type for 'ephemeral' (bool expected)")
         if not isinstance(sequence, bool):
             raise TypeError("Invalid type for 'sequence' (bool expected)")
+        if not isinstance(include_data, bool):
+            raise TypeError("Invalid type for 'include_data' (bool expected)")
 
         flags = 0
         if ephemeral:
@@ -1620,8 +1622,12 @@ class TransactionRequest(object):
             flags |= 2
         if acl is None:
             acl = OPEN_ACL_UNSAFE
+        if include_data:
+            opcode = Create2
+        else:
+            opcode = Create
 
-        self._add(Create(_prefix_root(self.client.chroot, path), value, acl,
+        self._add(opcode(_prefix_root(self.client.chroot, path), value, acl,
                          flags), None)
 
     def delete(self, path, version=-1):


### PR DESCRIPTION
Add `Create2` support in transactions.

Modeled after https://github.com/apache/zookeeper/blob/branch-3.5.6/zookeeper-server/src/main/java/org/apache/zookeeper/MultiResponse.java