### PR TITLE
Use chain.from_iterable in threading.py

### DIFF
--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -178,7 +178,7 @@ class SequentialThreadingHandler(object):
         # anything to minimize changes
         if _HAS_EPOLL:
             # if the highest fd we've seen is > 1023
-            if max(map(_to_fileno, chain(*args[:3]))) > 1023:
+            if max(map(_to_fileno, chain.from_iterable(args[:3]))) > 1023:
                 return self._epoll_select(*args, **kwargs)
         return self._select(*args, **kwargs)
 


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.