### PR TITLE
chore(core): Update matrix: add pypy3, drop py27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+os: linux
 dist: xenial
 addons:
   apt:
@@ -11,57 +11,33 @@ cache:
   directories:
   - zookeeper
 language: python
-python:
-- '2.7'
-matrix:
-  exclude:
-  - python: '2.7'
+jobs:
   include:
-  - python: '2.7'
-    env: ZOOKEEPER_VERSION=3.4.14 TOX_VENV=py27
-  - python: '2.7'
-    env: ZOOKEEPER_VERSION=3.5.7 ZOOKEEPER_PREFIX="apache-" ZOOKEEPER_SUFFIX="-bin" ZOOKEEPER_LIB="lib" TOX_VENV=py27
-  - python: '2.7'
-    env: ZOOKEEPER_VERSION=3.4.14 TOX_VENV=py27-gevent
-  - python: '2.7'
-    env: ZOOKEEPER_VERSION=3.5.7 ZOOKEEPER_PREFIX="apache-" ZOOKEEPER_SUFFIX="-bin" ZOOKEEPER_LIB="lib" TOX_VENV=py27-gevent
-  - python: '2.7'
-    env: ZOOKEEPER_VERSION=3.4.14 TOX_VENV=py27-eventlet
-  - python: '2.7'
-    env: ZOOKEEPER_VERSION=3.5.7 ZOOKEEPER_PREFIX="apache-" ZOOKEEPER_SUFFIX="-bin" ZOOKEEPER_LIB="lib" TOX_VENV=py27-eventlet
   - python: '3.7'
-    env: ZOOKEEPER_VERSION=3.4.14 TOX_VENV=py37
+    env: ZOOKEEPER_VERSION=3.4.14 TOX_VENV=py37-gevent-eventlet-sasl
   - python: '3.7'
-    env: ZOOKEEPER_VERSION=3.4.14 TOX_VENV=py37-sasl
-  - python: '3.7'
-    env: ZOOKEEPER_VERSION=3.5.7 ZOOKEEPER_PREFIX="apache-" ZOOKEEPER_SUFFIX="-bin" ZOOKEEPER_LIB="lib" TOX_VENV=py37
-  - python: '3.7'
-    env: ZOOKEEPER_VERSION=3.5.7 ZOOKEEPER_PREFIX="apache-" ZOOKEEPER_SUFFIX="-bin" ZOOKEEPER_LIB="lib" TOX_VENV=py37-sasl
+    env: ZOOKEEPER_VERSION=3.5.8 ZOOKEEPER_PREFIX="apache-" ZOOKEEPER_SUFFIX="-bin" ZOOKEEPER_LIB="lib" TOX_VENV=py37-gevent-eventlet-sasl
   - python: '3.8'
-    env: ZOOKEEPER_VERSION=3.4.14 TOX_VENV=py38
+    env: ZOOKEEPER_VERSION=3.4.14 TOX_VENV=py38-gevent-eventlet-sasl
   - python: '3.8'
-    env: ZOOKEEPER_VERSION=3.4.14 TOX_VENV=py38-sasl
-  - python: '3.8'
-    env: ZOOKEEPER_VERSION=3.5.7 ZOOKEEPER_PREFIX="apache-" ZOOKEEPER_SUFFIX="-bin" ZOOKEEPER_LIB="lib" TOX_VENV=py38 DEPLOY=true
-  - python: '3.8'
-    env: ZOOKEEPER_VERSION=3.5.7 ZOOKEEPER_PREFIX="apache-" ZOOKEEPER_SUFFIX="-bin" ZOOKEEPER_LIB="lib" TOX_VENV=py38-sasl
-  - python: pypy
-    env: ZOOKEEPER_VERSION=3.4.14 TOX_VENV=pypy
-  - python: 'pypy'
-    env: ZOOKEEPER_VERSION=3.5.7 ZOOKEEPER_PREFIX="apache-" ZOOKEEPER_SUFFIX="-bin" ZOOKEEPER_LIB="lib" TOX_VENV=pypy
+    env: ZOOKEEPER_VERSION=3.5.8 ZOOKEEPER_PREFIX="apache-" ZOOKEEPER_SUFFIX="-bin" ZOOKEEPER_LIB="lib" TOX_VENV=py38-gevent-eventlet-sasl DEPLOY=true
+  - python: 'pypy3'
+    env: ZOOKEEPER_VERSION=3.4.14 TOX_VENV=pypy3-gevent-eventlet-sasl
+  - python: 'pypy3'
+    env: ZOOKEEPER_VERSION=3.5.8 ZOOKEEPER_PREFIX="apache-" ZOOKEEPER_SUFFIX="-bin" ZOOKEEPER_LIB="lib" TOX_VENV=pypy3-gevent-eventlet-sasl
 notifications:
   email: false
 install:
 - pip install tox
 script:
-- make test
+- tox -e ${TOX_VENV}
 deploy:
   provider: pypi
-  user: bbangert
+  username: bbangert
   password:
     secure: L9yXZ2PhQ2wJKQkgigIzW3f/a3ajzUamMdThVelcp/NZeTJfzlC/t89lfSRwLh95o9Z/aIxC4T8yZvNrRzzyMEP0O6s1F69pVm5Px+KBuv82lmI7p5sKTYPp35CE9jH+K/52Fy0+Az5F502xLrkaO4VLLA+zhLffw/qyvNbZui0=
   on:
     tags: true
     condition: $DEPLOY = true
   distributions: release
-  skip_upload_docs: true
+  upload_docs: false

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HERE = $(shell pwd)
 BIN = $(HERE)/bin
 PYTHON = $(BIN)/python
 INSTALL = $(BIN)/pip install
-TOX_VENV ?= py27
+TOX_VENV ?= py37
 BUILD_DIRS = bin build include lib lib64 man share
 
 PYTHON_EXE = $(shell [ -f $(PYTHON) ] && echo $(PYTHON) || echo python)

--- a/tox.ini
+++ b/tox.ini
@@ -3,17 +3,9 @@ minversion = 3.6
 skipsdist = True
 envlist =
     pep8,
-    py27,
-    py27-{gevent,eventlet,sasl},
-    py34,
-    py34-sasl,
-    py35,
-    py35-sasl,
-    py36,
-    py36-{sasl,docs},
-    py37,
-    py37-{gevent,eventlet,sasl,docs},
-    pypy
+    {py27,py34,py35,py36,py37,py38,pypy3}
+    {gevent,eventlet,sasl,docs},
+    pypy3
 
 [testenv:pep8]
 commands = flake8 {posargs}


### PR DESCRIPTION
## Why is this needed?

By dropping py2.7 and pypy, we drop the last of the py2.x syntax from our tests matrix

## Proposed Changes

  - Tests are now only run only on py37, py38 and pypy3.
  - All py versions run all tests with gevent and sasl.
  - Bumped Zookeeper to 3.5.8.
  - Update .travis.yml definition per warnings, only syntax refresh.


