### PR TITLE
test: add SSL test

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.10-v7.3.15"]
         zk-version: ["3.4.14", "3.5.10", "3.6.3", "3.7.1"]
         include:
           - python-version: "3.7"
@@ -63,7 +63,7 @@ jobs:
             tox-env: py39
           - python-version: "3.10"
             tox-env: py310
-          - python-version: "pypy-3.7"
+          - python-version: "pypy-3.10-v7.3.15"
             tox-env: pypy3
     steps:
       - uses: actions/checkout@v4

--- a/kazoo/testing/harness.py
+++ b/kazoo/testing/harness.py
@@ -174,6 +174,10 @@ class KazooTestHarness(unittest.TestCase):
     def servers(self):
         return ",".join([s.address for s in self.cluster])
 
+    @property
+    def secure_servers(self):
+        return ",".join([s.secure_address for s in self.cluster])
+
     def _get_nonchroot_client(self):
         c = KazooClient(self.servers)
         self._clients.append(c)
@@ -234,7 +238,10 @@ class KazooTestHarness(unittest.TestCase):
                     self.cluster.terminate()
                     self.cluster.start()
                 continue
-
+        if client_options.get("use_ssl"):
+            self.hosts = self.secure_servers + namespace
+        else:
+            self.hosts = self.servers + namespace
         self.client = self._get_client(**client_options)
         self.client.start()
         self.client.ensure_path("/")

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,8 @@ test =
     pytest-cov
     gevent>=1.2 ; implementation_name!='pypy'
     eventlet>=0.17.1 ; implementation_name!='pypy'
+    pyjks
+    pyopenssl
 
 eventlet =
     eventlet>=0.17.1


### PR DESCRIPTION
This adds a simple SSL test along with the framework for running
the test Zookeeper in a mode where it listens on both SSL and
non-SSL ports.

This is based on earlier work in #619.
