### PR TITLE
fix(client.py): Prevent unnecessary retries

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -80,7 +80,7 @@ log = logging.getLogger(__name__)
 
 
 _RETRY_COMPAT_DEFAULTS = dict(
-    max_retries=None,
+    max_retries=0,
     retry_delay=0.1,
     retry_backoff=2,
     retry_max_delay=3600,


### PR DESCRIPTION
Fixes #

## Why is this needed?
  When max_retry(old parameters) is not assigned, it results in an infinite retry until time_out
## Proposed Changes
  - change1: kazoo.client.py:
    `
_RETRY_COMPAT_DEFAULTS = dict(
    max_retries=0,
    retry_delay=0.1,
    retry_backoff=2,
    retry_max_delay=3600,
)
`
## Does this PR introduce any breaking change?
  Reduce the times of hidden and unnecessary retries

