### PR TITLE
Cannot resolve .. [Errno -2] Name or service not known

### DIFF
--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -543,6 +543,8 @@ class ConnectionHandler(object):
 
         # Check for an empty hostlist, indicating none resolved
         if len(host_ports) == 0:
+            if len(self.client.hosts) == 1:
+                raise ForceRetryError('Reconnecting')
             return STOP_CONNECTING
 
         for host, hostip, port in host_ports:

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -543,9 +543,7 @@ class ConnectionHandler(object):
 
         # Check for an empty hostlist, indicating none resolved
         if len(host_ports) == 0:
-            if len(self.client.hosts) == 1:
-                raise ForceRetryError('Reconnecting')
-            return STOP_CONNECTING
+            raise ForceRetryError('No host resolved. Reconnecting')
 
         for host, hostip, port in host_ports:
             if self.client._stopped.is_set():


### PR DESCRIPTION
Fixes #

## Why is this needed?

Zookeeper is running from Docker containers and the service being resolved using Consul. When there's a network issue, the call to `socket.getaddrinfo` in method `_expand_client_hosts` causing it to return the error `Cannot resolve .. [Errno -2] Name or service not known`. This is causing retry to throwback `STOP_CONNECTING` and it stops retrying as result.

## Proposed Changes

Change: Raise `ForceRetryError` if method `_expand_client_hosts` returns empty host/ports and `client.hosts` has only one host to resolve.

```
        # Check for an empty hostlist, indicating none resolved
        if len(host_ports) == 0:
            if len(self.client.hosts) == 1:
                raise ForceRetryError('Reconnecting')
            return STOP_CONNECTING
```

## Does this PR introduce any breaking change?
n/a
