### PR TITLE
docs: fix simple typo, untill -> until

### DIFF
--- a/kazoo/recipe/queue.py
+++ b/kazoo/recipe/queue.py
@@ -220,7 +220,7 @@ class LockingQueue(BaseQueue):
 
         :param timeout:
             Maximum waiting time in seconds. If None then it will wait
-            untill an entry appears in the queue.
+            until an entry appears in the queue.
         :returns: A locked entry value or None if the timeout was reached.
         :rtype: bytes
         """


### PR DESCRIPTION
There is a small typo in kazoo/recipe/queue.py.

Should read `until` rather than `untill`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md