### PR TITLE
SequentialThreadingHandler support thread pool

### DIFF
--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -20,6 +20,7 @@ import select
 import socket
 import threading
 import time
+from multiprocessing.pool import ThreadPool
 
 import six
 
@@ -112,6 +113,7 @@ class SequentialThreadingHandler(object):
         self._running = False
         self._state_change = threading.Lock()
         self._workers = []
+        self._pool = ThreadPool(30)
 
     @property
     def running(self):
@@ -280,6 +282,9 @@ class SequentialThreadingHandler(object):
         t.daemon = True
         t.start()
         return t
+
+    def safe_spawn(self, func, *args, **kwargs):
+        self._pool.apply_async(func, args, kwargs)
 
     def dispatch_callback(self, callback):
         """Dispatch to the callback object

--- a/kazoo/interfaces.py
+++ b/kazoo/interfaces.py
@@ -99,6 +99,17 @@ class IHandler(object):
 
         """
 
+    def safe_spawn(self, func, *args, **kwargs):
+        """Safely spawn a function to run asynchronously, use pool
+
+        :param args: args to call the function with.
+        :param kwargs: keyword args to call the function with.
+
+        This method should return immediately and execute the function
+        with the provided args and kwargs in an asynchronous manner.
+
+        """
+
 
 class IAsyncResult(object):
     """An Async Result object that can be queried for a value that has

--- a/kazoo/recipe/watchers.py
+++ b/kazoo/recipe/watchers.py
@@ -191,7 +191,7 @@ class DataWatch(object):
                 stat = self._retry(self._client.exists, self._path,
                                    self._watcher)
                 if stat:
-                    self._client.handler.spawn(self._get_data)
+                    self._client.handler.safe_spawn(self._get_data)
                     return
 
             # No node data, clear out version
@@ -214,7 +214,7 @@ class DataWatch(object):
 
     def _session_watcher(self, state):
         if state == KazooState.CONNECTED:
-            self._client.handler.spawn(self._get_data)
+            self._client.handler.safe_spawn(self._get_data)
 
 
 class ChildrenWatch(object):
@@ -356,7 +356,7 @@ class ChildrenWatch(object):
             self._watch_established = False
         elif (state == KazooState.CONNECTED and
               not self._watch_established and not self._stopped):
-            self._client.handler.spawn(self._get_children)
+            self._client.handler.safe_spawn(self._get_children)
 
 
 class PatientChildrenWatch(object):
@@ -404,7 +404,7 @@ class PatientChildrenWatch(object):
 
         """
         self.asy = asy = self.client.handler.async_result()
-        self.client.handler.spawn(self._inner_start)
+        self.client.handler.safe_spawn(self._inner_start)
         return asy
 
     def _inner_start(self):


### PR DESCRIPTION
1. SequentialThreadingHandler support thread pool
2. DataWatch use thread pool version spawn in order to supper high
   frequency data update event

Fixes #

## Why is this needed?

## Proposed Changes

  - change 1
  - change 2
  - ...

## Does this PR introduce any breaking change?

