### PR TITLE
fix:  use  selectors instead of raw select in all handlers

### DIFF
--- a/kazoo/handlers/eventlet.py
+++ b/kazoo/handlers/eventlet.py
@@ -5,15 +5,15 @@ import contextlib
 import logging
 
 import eventlet
-from eventlet.green import select as green_select
 from eventlet.green import socket as green_socket
 from eventlet.green import time as green_time
 from eventlet.green import threading as green_threading
+from eventlet.green import selectors as green_selectors
 from eventlet import queue as green_queue
 
 from kazoo.handlers import utils
 import kazoo.python2atexit as python2atexit
-
+from kazoo.handlers.utils import _selector_select
 
 LOG = logging.getLogger(__name__)
 
@@ -41,6 +41,7 @@ class TimeoutError(Exception):
 
 class AsyncResult(utils.AsyncResult):
     """A one-time event that stores a value or an exception"""
+
     def __init__(self, handler):
         super(AsyncResult, self).__init__(handler,
                                           green_threading.Condition,
@@ -164,7 +165,8 @@ class SequentialEventletHandler(object):
 
     def select(self, *args, **kwargs):
         with _yield_before_after():
-            return green_select.select(*args, **kwargs)
+            return _selector_select(*args, **kwargs,
+                                    selectors_module=green_selectors)
 
     def async_result(self):
         return AsyncResult(self)

--- a/kazoo/handlers/gevent.py
+++ b/kazoo/handlers/gevent.py
@@ -9,6 +9,10 @@ import gevent.event
 import gevent.queue
 import gevent.select
 import gevent.thread
+import gevent.selectors
+
+from kazoo.handlers.utils import _selector_select
+
 try:
     from gevent.lock import Semaphore, RLock
 except ImportError:
@@ -16,7 +20,6 @@ except ImportError:
 
 from kazoo.handlers import utils
 from kazoo import python2atexit
-
 
 _using_libevent = gevent.__version__.startswith('0.')
 
@@ -84,6 +87,7 @@ class SequentialGeventHandler(object):
                         del func  # release before possible idle
                 except self.queue_empty:
                     continue
+
         return gevent.spawn(greenlet_worker)
 
     def start(self):
@@ -122,7 +126,8 @@ class SequentialGeventHandler(object):
             python2atexit.unregister(self.stop)
 
     def select(self, *args, **kwargs):
-        return gevent.select.select(*args, **kwargs)
+        return _selector_select(*args, **kwargs,
+                                selectors_module=gevent.selectors)
 
     def socket(self, *args, **kwargs):
         return utils.create_tcp_socket(socket)

--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -12,11 +12,7 @@ environments that use threads.
 """
 from __future__ import absolute_import
 
-from collections import defaultdict
-import errno
-from itertools import chain
 import logging
-import select
 import socket
 import threading
 import time
@@ -25,19 +21,17 @@ import six
 
 import kazoo.python2atexit as python2atexit
 from kazoo.handlers import utils
+from kazoo.handlers.utils import _selector_select
 
 try:
     import Queue
 except ImportError:  # pragma: nocover
     import queue as Queue
 
-
 # sentinel objects
 _STOP = object()
 
 log = logging.getLogger(__name__)
-
-_HAS_EPOLL = hasattr(select, "epoll")
 
 
 def _to_fileno(obj):
@@ -65,6 +59,7 @@ class KazooTimeoutError(Exception):
 
 class AsyncResult(utils.AsyncResult):
     """A one-time event that stores a value or an exception"""
+
     def __init__(self, handler):
         super(AsyncResult, self).__init__(handler,
                                           threading.Condition,
@@ -133,6 +128,7 @@ class SequentialThreadingHandler(object):
                         del func  # release before possible idle
                 except self.queue_empty:
                     continue
+
         t = self.spawn(_thread_worker)
         return t
 
@@ -173,82 +169,7 @@ class SequentialThreadingHandler(object):
             python2atexit.unregister(self.stop)
 
     def select(self, *args, **kwargs):
-        # if we have epoll, and select is not expected to work
-        # use an epoll-based "select". Otherwise don't touch
-        # anything to minimize changes
-        if _HAS_EPOLL:
-            # if the highest fd we've seen is > 1023
-            if max(map(_to_fileno, chain.from_iterable(args[:3]))) > 1023:
-                return self._epoll_select(*args, **kwargs)
-        return self._select(*args, **kwargs)
-
-    def _select(self, *args, **kwargs):
-        timeout = kwargs.pop('timeout', None)
-        # either the time to give up, or None
-        end = (time.time() + timeout) if timeout else None
-        while end is None or time.time() < end:
-            if end is not None:
-                # make a list, since tuples aren't mutable
-                args = list(args)
-
-                # set the timeout to the remaining time
-                args[3] = end - time.time()
-            try:
-                return select.select(*args, **kwargs)
-            except select.error as ex:
-                # if the system call was interrupted, we'll retry until timeout
-                # in Python 3, system call interruptions are a native exception
-                # in Python 2, they are not
-                errnum = ex.errno if isinstance(ex, OSError) else ex[0]
-                if errnum == errno.EINTR:
-                    continue
-                raise
-        # if we hit our timeout, lets return as a timeout
-        return ([], [], [])
-
-    def _epoll_select(self, rlist, wlist, xlist, timeout=None):
-        """epoll-based drop-in replacement for select to overcome select
-        limitation on a maximum filehandle value
-        """
-        if timeout is None:
-            timeout = -1
-        eventmasks = defaultdict(int)
-        rfd2obj = defaultdict(list)
-        wfd2obj = defaultdict(list)
-        xfd2obj = defaultdict(list)
-        read_evmask = select.EPOLLIN | select.EPOLLPRI  # Just in case
-
-        def store_evmasks(obj_list, evmask, fd2obj):
-            for obj in obj_list:
-                fileno = _to_fileno(obj)
-                eventmasks[fileno] |= evmask
-                fd2obj[fileno].append(obj)
-
-        store_evmasks(rlist, read_evmask, rfd2obj)
-        store_evmasks(wlist, select.EPOLLOUT, wfd2obj)
-        store_evmasks(xlist, select.EPOLLERR, xfd2obj)
-
-        poller = select.epoll()
-
-        for fileno in eventmasks:
-            poller.register(fileno, eventmasks[fileno])
-
-        try:
-            events = poller.poll(timeout)
-            revents = []
-            wevents = []
-            xevents = []
-            for fileno, event in events:
-                if event & read_evmask:
-                    revents += rfd2obj.get(fileno, [])
-                if event & select.EPOLLOUT:
-                    wevents += wfd2obj.get(fileno, [])
-                if event & select.EPOLLERR:
-                    xevents += xfd2obj.get(fileno, [])
-        finally:
-            poller.close()
-
-        return revents, wevents, xevents
+        return _selector_select(*args, **kwargs)
 
     def socket(self):
         return utils.create_tcp_socket(socket)

--- a/kazoo/tests/test_threading_handler.py
+++ b/kazoo/tests/test_threading_handler.py
@@ -45,10 +45,6 @@ class TestThreadingHandler(unittest.TestCase):
         assert h._running is False
 
     def test_huge_file_descriptor(self):
-        from kazoo.handlers.threading import _HAS_EPOLL
-
-        if not _HAS_EPOLL:
-            self.skipTest('only run on systems with epoll()')
         import resource
         import socket
         from kazoo.handlers.utils import create_tcp_socket
@@ -66,9 +62,6 @@ class TestThreadingHandler(unittest.TestCase):
         h = self._makeOne()
         h.start()
         h.select(socks, [], [])
-        with pytest.raises(ValueError):
-            h._select(socks, [], [])
-        h._epoll_select(socks, [], [])
         h.stop()
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ import re
 from setuptools import setup, find_packages
 import sys
 
-
 here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'README.md')) as f:
     README = f.read()
@@ -16,7 +15,7 @@ with open(os.path.join(here, 'kazoo', 'version.py')) as f:
 
 PYPY = getattr(sys, 'pypy_version_info', False) and True or False
 
-install_requires = ['six']
+install_requires = ['six', 'selectors2>=2.0.2; python_version < "3.4.0"']
 
 tests_require = install_requires + [
     'mock',


### PR DESCRIPTION
Use selectors to poll connections instead of raw select in all kinds of handlers. To solve the limitation on a maximum file handler value and dynamic choose the best poller in the system.

## Why is this needed?

In the current implementation, the gevent, eventlet handler use the old select fuction which not support fd number langer than 1023 . Network Program with high numbers of opened sockets often raise `Exception: filedescriptor out of range in select()` 

## Proposed Changes

  - Use the `selectors` module which ship with official  python distro >=3.4 to simulate the select interface.
  - Change the select fuction in all handlers to use the `selectors` implementation.
  - The `selectors` will choose the best poller in the system.


