### PR TITLE
fix(core): use selectors to poll connections instead of raw select in threading,gevent,eventlet; solve the select limitation on a maximum file handler value and dynamic choose the best poller in the system

### DIFF
--- a/kazoo/handlers/eventlet.py
+++ b/kazoo/handlers/eventlet.py
@@ -5,15 +5,15 @@ import contextlib
 import logging
 
 import eventlet
-from eventlet.green import select as green_select
 from eventlet.green import socket as green_socket
 from eventlet.green import time as green_time
 from eventlet.green import threading as green_threading
+from eventlet.green import selectors as green_selectors
 from eventlet import queue as green_queue
 
 from kazoo.handlers import utils
 import kazoo.python2atexit as python2atexit
-
+from kazoo.handlers.utils import selector_select
 
 LOG = logging.getLogger(__name__)
 
@@ -41,6 +41,7 @@ class TimeoutError(Exception):
 
 class AsyncResult(utils.AsyncResult):
     """A one-time event that stores a value or an exception"""
+
     def __init__(self, handler):
         super(AsyncResult, self).__init__(handler,
                                           green_threading.Condition,
@@ -164,7 +165,8 @@ class SequentialEventletHandler(object):
 
     def select(self, *args, **kwargs):
         with _yield_before_after():
-            return green_select.select(*args, **kwargs)
+            return selector_select(*args, selectors_module=green_selectors,
+                                   **kwargs)
 
     def async_result(self):
         return AsyncResult(self)

--- a/kazoo/tests/test_selectors_select.py
+++ b/kazoo/tests/test_selectors_select.py
@@ -1,0 +1,91 @@
+"""
+The official python select function test case copied from python source
+ to test the selector_select function.
+"""
+
+import errno
+import os
+import socket
+import sys
+import unittest
+from test import support
+from kazoo.handlers.utils import selector_select
+
+select = selector_select
+
+
+@unittest.skipIf((sys.platform[:3] == 'win'),
+                 "can't easily test on this system")
+class SelectTestCase(unittest.TestCase):
+    class Nope:
+        pass
+
+    class Almost:
+        def fileno(self):
+            return 'fileno'
+
+    def test_error_conditions(self):
+        self.assertRaises(TypeError, select, 1, 2, 3)
+        self.assertRaises(TypeError, select, [self.Nope()], [], [])
+        self.assertRaises(TypeError, select, [self.Almost()], [], [])
+        self.assertRaises(TypeError, select, [], [], [], "not a number")
+        self.assertRaises(ValueError, select, [], [], [], -1)
+
+    # Issue #12367: http://www.freebsd.org/cgi/query-pr.cgi?pr=kern/155606
+    @unittest.skipIf(sys.platform.startswith('freebsd'),
+                     'skip because of a FreeBSD bug: kern/155606')
+    def test_errno(self):
+        with open(__file__, 'rb') as fp:
+            fd = fp.fileno()
+            fp.close()
+            try:
+                select([fd], [], [], 0)
+            except OSError as err:
+                self.assertEqual(err.errno, errno.EBADF)
+            else:
+                self.fail("exception not raised")
+
+    def test_returned_list_identity(self):
+        # See issue #8329
+        r, w, x = select([], [], [], 1)
+        self.assertIsNot(r, w)
+        self.assertIsNot(r, x)
+        self.assertIsNot(w, x)
+
+    def test_select(self):
+        cmd = 'for i in 0 1 2 3 4 5 6 7 8 9; do echo testing...; sleep 1; done'
+        p = os.popen(cmd, 'r')
+        for tout in (0, 1, 2, 4, 8, 16) + (None,) * 10:
+            if support.verbose:
+                print('timeout =', tout)
+            rfd, wfd, xfd = select([p], [], [], tout)
+            if (rfd, wfd, xfd) == ([], [], []):
+                continue
+            if (rfd, wfd, xfd) == ([p], [], []):
+                line = p.readline()
+                if support.verbose:
+                    print(repr(line))
+                if not line:
+                    if support.verbose:
+                        print('EOF')
+                    break
+                continue
+            self.fail('Unexpected return values from select():', rfd, wfd, xfd)
+        p.close()
+
+    # Issue 16230: Crash on select resized list
+    def test_select_mutated(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            a = []
+
+            class F:
+                def fileno(self):
+                    del a[-1]
+                    return s.fileno()
+
+            a[:] = [F()] * 10
+            self.assertEqual(select([], a, []), ([], a[:5], []))
+
+
+def tearDownModule():
+    support.reap_children()

--- a/kazoo/tests/test_threading_handler.py
+++ b/kazoo/tests/test_threading_handler.py
@@ -45,10 +45,6 @@ class TestThreadingHandler(unittest.TestCase):
         assert h._running is False
 
     def test_huge_file_descriptor(self):
-        from kazoo.handlers.threading import _HAS_EPOLL
-
-        if not _HAS_EPOLL:
-            self.skipTest('only run on systems with epoll()')
         import resource
         import socket
         from kazoo.handlers.utils import create_tcp_socket
@@ -65,11 +61,10 @@ class TestThreadingHandler(unittest.TestCase):
             socks.append(sock)
         h = self._makeOne()
         h.start()
-        h.select(socks, [], [])
-        with pytest.raises(ValueError):
-            h._select(socks, [], [])
-        h._epoll_select(socks, [], [])
+        h.select(socks, [], [], 0)
         h.stop()
+        for sock in socks:
+            sock.close()
 
 
 class TestThreadingAsync(unittest.TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 six
+selectors2>=2.0.2; python_version < "3.4.0"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ import re
 from setuptools import setup, find_packages
 import sys
 
-
 here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'README.md')) as f:
     README = f.read()
@@ -16,7 +15,7 @@ with open(os.path.join(here, 'kazoo', 'version.py')) as f:
 
 PYPY = getattr(sys, 'pypy_version_info', False) and True or False
 
-install_requires = ['six']
+install_requires = ['six', 'selectors2>=2.0.2; python_version < "3.4.0"']
 
 tests_require = install_requires + [
     'mock',


### PR DESCRIPTION
Use selectors to poll connections instead of raw select in all kinds of handlers. To solve the limitation on a maximum file handler value and dynamic choose the best poller in the system.

## Why is this needed?

In the current implementation, the gevent, eventlet handler use the old select fuction which not support fd number langer than 1023 . Network Program with high numbers of opened sockets often raise `Exception: filedescriptor out of range in select()` 

## Proposed Changes

  - Use the `selectors` module which ship with official  python distro >=3.4 to simulate the select interface.
  - Change the select fuction in all handlers to use the `selectors` implementation.
  - The `selectors` will choose the best poller in the system.
