### PR TITLE
fix(recipe): fix deprecation warning from threading.Event

### DIFF
--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -276,7 +276,7 @@ class Lock(object):
                 pass  # predecessor has already been deleted
             else:
                 self.wake_event.wait(timeout)
-                if not self.wake_event.isSet():
+                if not self.wake_event.is_set():
                     raise LockTimeout(
                         "Failed to acquire lock on %s after %s seconds"
                         % (self.path, timeout)
@@ -638,7 +638,7 @@ class Semaphore(object):
                     # If blocking, wait until self._watch_lease_change() is
                     # called before returning
                     self.wake_event.wait(w.leftover())
-                    if not self.wake_event.isSet():
+                    if not self.wake_event.is_set():
                         raise LockTimeout(
                             "Failed to acquire semaphore on %s"
                             " after %s seconds" % (self.path, timeout)

--- a/kazoo/recipe/queue.py
+++ b/kazoo/recipe/queue.py
@@ -292,7 +292,7 @@ class LockingQueue(BaseQueue):
             if event is not None and event.type != EventType.CHILD:
                 return
             with lock:
-                if canceled or flag.isSet():
+                if canceled or flag.is_set():
                     return
                 values = self.client.retry(
                     self.client.get_children,

--- a/kazoo/testing/harness.py
+++ b/kazoo/testing/harness.py
@@ -229,11 +229,11 @@ class KazooTestHarness(unittest.TestCase):
         self.client._call(break_event, None)
 
         lost.wait(5)
-        if not lost.isSet():
+        if not lost.is_set():
             raise Exception("Failed to get notified of broken connection.")
 
         safe.wait(15)
-        if not safe.isSet():
+        if not safe.is_set():
             raise Exception("Failed to see client reconnect.")
 
         self.client.retry(self.client.get_async, '/')

--- a/kazoo/tests/test_lock.py
+++ b/kazoo/tests/test_lock.py
@@ -397,7 +397,7 @@ class KazooLockTests(KazooTestCase):
             with lock:
                 started.set()
                 event.wait(timeout)
-                if not event.isSet():
+                if not event.is_set():
                     # Eventually fail to avoid hanging the tests
                     self.fail("lock2 never timed out")
 
@@ -409,7 +409,7 @@ class KazooLockTests(KazooTestCase):
         client2 = self._get_client()
         client2.start()
         started.wait(5)
-        assert started.isSet() is True
+        assert started.is_set() is True
         lock2 = client2.Lock(self.lockpath, "two")
         try:
             lock2.acquire(timeout=timeout)
@@ -712,7 +712,7 @@ class TestSemaphore(KazooTestCase):
             with sem:
                 started.set()
                 event.wait(timeout)
-                if not event.isSet():
+                if not event.is_set():
                     # Eventually fail to avoid hanging the tests
                     self.fail("sem2 never timed out")
 
@@ -724,7 +724,7 @@ class TestSemaphore(KazooTestCase):
         client2 = self._get_client()
         client2.start()
         started.wait(5)
-        assert started.isSet() is True
+        assert started.is_set() is True
         sem2 = client2.Semaphore(self.lockpath, "two")
         try:
             sem2.acquire(timeout=timeout)


### PR DESCRIPTION
Fix deprecation warning emitted when calling `threading.Event.isSet`

## Why is this needed?

Reasoning:
- `is_set` is supported since Python2.6 (https://docs.python.org/2.7/library/threading.html)
- Starting from Python3.5 docs the `isSet` spelling is not even mentioned anymore (https://docs.python.org/3.5/library/threading.html)
- Python3.10 will give a deprecation warning when the `isSet` spelling is used (https://docs.python.org/3.10/library/threading.html)

## Proposed Changes

- just use is_set over isSet

## Does this PR introduce any breaking change?

- only for users of python version below 2.6; python2.5 is not supported according to setup.py