### PR TITLE
chore(ci): better specify how to trigger Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Kazoo Awesome Release
 
-on: [push]
+on:
+  push:
+    tags:
+      - '*'
 
 jobs:
   build-and-release:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,6 +1,14 @@
 name: Kazoo Awesome Testing
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - release/*
+  pull_request:
+    branches:
+      - master
+      - release/*
 
 jobs:
   test:


### PR DESCRIPTION
## Why is this needed?
Current configuration of Github Actions only trigger on push on the repo, but not on pull requets, which is kind of limited.

## Proposed Changes

  - trigger GA on push to master and release/* branches
  - trigger GA on pull request with master or release/* branches as destination

## Does this PR introduce any breaking change?
Nah
