### PR TITLE
add GitHub URL for PyP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,9 @@ setup(
     author="Kazoo team",
     author_email="python-zk@googlegroups.com",
     url="https://kazoo.readthedocs.io",
+    project_urls={
+        "Source": "https://github.com/python-zk/kazoo",
+    },
     license="Apache 2.0",
     packages=find_packages(),
     test_suite="kazoo.tests",

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
     url="https://kazoo.readthedocs.io",
     project_urls={
         "Source": "https://github.com/python-zk/kazoo",
+        "Changelog": "https://github.com/python-zk/kazoo/releases",
     },
     license="Apache 2.0",
     packages=find_packages(),


### PR DESCRIPTION
Fixes #

## Why is this needed?

Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)


## Proposed Changes

  - change 1
  - change 2
  - ...

## Does this PR introduce any breaking change?

