### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,4 @@
 build-backend = 'setuptools.build_meta'
 requires = [
     'setuptools >= 46.4.0',
-    'wheel'
 ]


### PR DESCRIPTION
## Why is this needed?
Remove the redundant `wheel` dependency, as it is added by the backend automatically.  Listing it explicitly in the documentation was a historical mistake and has been fixed since, see: https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a

## Proposed Changes

  - remove `wheel` from `pyproject.toml`

## Does this PR introduce any breaking change?

No.