### PR TITLE
fix(core): fix for Windows platform

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,11 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Handle the code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: "Set up Python 3.10"
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
@@ -47,9 +45,8 @@ jobs:
     needs: [validate]
 
     name: >
-      Test Python ${{ matrix.python-version }},
+      Linux - Test Python ${{ matrix.python-version }},
       ZK ${{ matrix.zk-version }}
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -69,8 +66,7 @@ jobs:
           - python-version: "pypy-3.7"
             tox-env: pypy3
     steps:
-      - name: Handle the code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -111,3 +107,52 @@ jobs:
 
       - name: Publish Codecov report
         uses: codecov/codecov-action@v3
+
+  test_windows:
+    needs: [validate]
+    name: Windows - Sanity test using a single version of Python and ZK
+
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Handle pip cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Handle ZK installation cache
+        uses: actions/cache@v3
+        with:
+          path: zookeeper
+          key: ${{ runner.os }}-zookeeper
+          restore-keys: |
+            ${{ runner.os }}-zookeeper
+
+      # https://github.com/actions/setup-java
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install required dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install tox
+
+      - name: Test with tox
+        run: tox -e py310
+        env:
+          ZOOKEEPER_VERSION: 3.7.1
+          ZOOKEEPER_PREFIX: "apache-"
+          ZOOKEEPER_SUFFIX: "-bin"
+          ZOOKEEPER_LIB: "lib"
+        shell: bash

--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -382,7 +382,7 @@ def selector_select(
             selector.register(fd, events)
         except (ValueError, OSError) as e:
             # gevent can raise OSError
-            raise ValueError('Invalid event mask or fd') from e
+            raise ValueError("Invalid event mask or fd") from e
 
     revents, wevents, xevents = [], [], []
     try:

--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -209,7 +209,6 @@ class Lock(object):
         return True
 
     def _inner_acquire(self, blocking, timeout, ephemeral=True):
-
         # wait until it's our chance to get it..
         if self.is_acquired:
             if not blocking:

--- a/kazoo/testing/common.py
+++ b/kazoo/testing/common.py
@@ -240,7 +240,7 @@ log4j.appender.ROLLINGFILE.File="""
         jars = glob((os.path.join(self.install_path, "zookeeper-*.jar")))
         if jars:
             # Release build (`ant package`)
-            jars.extend(glob(os.path.join(self.install_path, "lib/*.jar")))
+            jars.extend(glob(os.path.join(self.install_path, "lib", "*.jar")))
             jars.extend(glob(os.path.join(self.install_path, "*.jar")))
             # support for different file locations on Debian/Ubuntu
             jars.extend(glob(os.path.join(self.install_path, "log4j-*.jar")))
@@ -253,10 +253,10 @@ log4j.appender.ROLLINGFILE.File="""
         else:
             # Development build (plain `ant`)
             jars = glob(
-                (os.path.join(self.install_path, "build/zookeeper-*.jar"))
+                (os.path.join(self.install_path, "build", "zookeeper-*.jar"))
             )
             jars.extend(
-                glob(os.path.join(self.install_path, "build/lib/*.jar"))
+                glob(os.path.join(self.install_path, "build", "lib", "*.jar"))
             )
 
         return os.pathsep.join(jars)

--- a/kazoo/tests/test_cache.py
+++ b/kazoo/tests/test_cache.py
@@ -1,5 +1,6 @@
 import gc
 import importlib
+import sys
 import uuid
 
 from unittest.mock import patch, call, Mock
@@ -28,6 +29,11 @@ class KazooAdaptiveHandlerTestCase(KazooTestHarness):
 
     def choose_an_installed_handler(self):
         for handler_module, handler_class in self.HANDLERS:
+            if (
+                handler_module == "kazoo.handlers.gevent"
+                and sys.platform == "win32"
+            ):
+                continue
             try:
                 mod = importlib.import_module(handler_module)
                 cls = getattr(mod, handler_class)

--- a/kazoo/tests/test_eventlet_handler.py
+++ b/kazoo/tests/test_eventlet_handler.py
@@ -131,7 +131,10 @@ class TestEventletHandler(unittest.TestCase):
             r.get()
 
     def test_huge_file_descriptor(self):
-        import resource
+        try:
+            import resource
+        except ImportError:
+            self.skipTest("resource module unavailable on this platform")
         from eventlet.green import socket
         from kazoo.handlers.utils import create_tcp_socket
 

--- a/kazoo/tests/test_gevent_handler.py
+++ b/kazoo/tests/test_gevent_handler.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 
 import pytest
 
@@ -9,6 +10,7 @@ from kazoo.testing import KazooTestCase
 from kazoo.tests import test_client
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 class TestGeventHandler(unittest.TestCase):
     def setUp(self):
         try:
@@ -77,6 +79,7 @@ class TestGeventHandler(unittest.TestCase):
         ev.wait()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 class TestBasicGeventClient(KazooTestCase):
     def setUp(self):
         try:
@@ -165,6 +168,7 @@ class TestBasicGeventClient(KazooTestCase):
             sock.close()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 class TestGeventClient(test_client.TestClient):
     def setUp(self):
         try:

--- a/kazoo/tests/test_hosts.py
+++ b/kazoo/tests/test_hosts.py
@@ -36,7 +36,6 @@ class HostsTestCase(TestCase):
         assert chroot is None
 
     def test_hosts_list(self):
-
         hosts, chroot = collect_hosts("zk01:2181, zk02:2181, zk03:2181")
         expected1 = [("zk01", 2181), ("zk02", 2181), ("zk03", 2181)]
         assert hosts == expected1

--- a/kazoo/tests/test_selectors_select.py
+++ b/kazoo/tests/test_selectors_select.py
@@ -3,7 +3,6 @@ The official python select function test case copied from python source
  to test the selector_select function.
 """
 
-import errno
 import os
 import socket
 import sys
@@ -41,12 +40,7 @@ class SelectTestCase(unittest.TestCase):
         with open(__file__, "rb") as fp:
             fd = fp.fileno()
             fp.close()
-            try:
-                select([fd], [], [], 0)
-            except OSError as err:
-                self.assertEqual(err.errno, errno.EBADF)
-            else:
-                self.fail("exception not raised")
+            self.assertRaises(ValueError, select, [fd], [], [], 0)
 
     def test_returned_list_identity(self):
         # See issue #8329

--- a/kazoo/tests/test_threading_handler.py
+++ b/kazoo/tests/test_threading_handler.py
@@ -45,7 +45,10 @@ class TestThreadingHandler(unittest.TestCase):
         assert h._running is False
 
     def test_huge_file_descriptor(self):
-        import resource
+        try:
+            import resource
+        except ImportError:
+            self.skipTest("resource module unavailable on this platform")
         import socket
         from kazoo.handlers.utils import create_tcp_socket
 

--- a/kazoo/tests/util.py
+++ b/kazoo/tests/util.py
@@ -98,7 +98,6 @@ class Wait(object):
         getnow=(lambda: time.time),
         getsleep=(lambda: time.sleep),
     ):
-
         if timeout is not None:
             self.timeout = timeout
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,9 @@ deps =
 allowlist_externals =
     {toxinidir}/ensure-zookeeper-env.sh
     {toxinidir}/init_krb5.sh
+    bash
 commands =
+        bash \
     sasl: {toxinidir}/init_krb5.sh {envtmpdir}/kerberos \
         {toxinidir}/ensure-zookeeper-env.sh \
         pytest {posargs: -ra -v --cov-report=xml --cov=kazoo kazoo/tests}


### PR DESCRIPTION
Fixes https://github.com/python-zk/kazoo/issues/679

## Why is this needed?
This fixes an issue with the Windows platform that appeared in the latest 2.9.0 release. This also adds a very basic testing for the Windows platform (only 1 job, for the latest version of Python and the latest version of ZK).

## Proposed Changes
  - remove the `os.fstat(fd)` check that is invalid on Windows platform
  - adjust `test_selector_select` test
  - add a single job to test Windows platform (`gevent` seems broken on Windows so... skipped it): only 1 job because I don't feel like we need to re-test every version of Python/ZK for Windows

## Does this PR introduce any breaking change?
Nah.
