### PR TITLE
recipe(cache): Use protocol.paths.join instead of os.path.join

### DIFF
--- a/kazoo/recipe/cache.py
+++ b/kazoo/recipe/cache.py
@@ -16,12 +16,10 @@ import contextlib
 import functools
 import logging
 import operator
-import os
 
 from kazoo.exceptions import NoNodeError, KazooException
-from kazoo.protocol.paths import _prefix_root
+from kazoo.protocol.paths import _prefix_root, join as kazoo_join
 from kazoo.protocol.states import KazooState, EventType
-
 
 logger = logging.getLogger(__name__)
 
@@ -336,7 +334,7 @@ class TreeNode(object):
             if result.successful():
                 children = result.get()
                 for child in sorted(children):
-                    full_path = os.path.join(path, child)
+                    full_path = kazoo_join(path, child)
                     if child not in self._children:
                         node = TreeNode(self._tree, full_path, self)
                         self._children[child] = node


### PR DESCRIPTION

Fixes #680 

## Why is this needed?

`os.path.join` doesWindows path joining on Windows resulting in bad zookeeper paths

## Proposed Changes

- use the existing path joining method in `kazoo.protocol.paths` instead of `os.path.join`.

## Does this PR introduce any breaking change?

No.