### PR TITLE
chore: add mypy to the build

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Code check
         run: tox -e ${TOX_VENV}
         env:
-          TOX_VENV: black,pep8
+          TOX_VENV: black,pep8,mypy
 
   test:
     needs: [validate]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,125 @@ extend-exclude = '''
 
 [tool.pytest.ini_options]
 addopts = "-ra -v"
+
+[tool.mypy]
+
+# For details on each flag, please see the mypy documentation at:
+# https://mypy.readthedocs.io/en/stable/config_file.html#config-file
+
+# Note: The order of flags listed here should match the order used in mypy's
+# documentation to make it easier to find the documentation for each flag.
+
+# Import Discovery
+ignore_missing_imports = false
+
+# Disallow dynamic typing
+disallow_any_unimported = true
+disallow_any_expr = false
+disallow_any_decorated = true
+disallow_any_explicit = true
+disallow_any_generics = true
+disallow_subclassing_any = true
+
+# Untyped definitions and calls
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+
+# None and Optional handling
+implicit_optional = false
+strict_optional = true
+
+# Configuring warnings
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_return_any = true
+warn_unreachable = true
+
+# Miscellaneous strictness flags
+allow_untyped_globals = false
+allow_redefinition = false
+local_partial_types = true
+implicit_reexport = false
+strict_concatenate = true
+strict_equality = true
+strict = true
+
+# Configuring error messages
+show_error_context = true
+show_column_numbers = true
+hide_error_codes = false
+pretty = true
+color_output = true
+error_summary = true
+show_absolute_path = true
+
+# Miscellaneous
+warn_unused_configs = true
+verbosity = 0
+
+# FIXME: As type annotations are introduced, please remove the appropriate
+#        ignore_errors flag below. New modules should NOT be added here!
+
+[[tool.mypy.overrides]]
+module = [
+    'kazoo.client',
+    'kazoo.exceptions',
+    'kazoo.handlers.eventlet',
+    'kazoo.handlers.gevent',
+    'kazoo.handlers.threading',
+    'kazoo.handlers.utils',
+    'kazoo.hosts',
+    'kazoo.interfaces',
+    'kazoo.loggingsupport',
+    'kazoo.protocol.connection',
+    'kazoo.protocol.paths',
+    'kazoo.protocol.serialization',
+    'kazoo.protocol.states',
+    'kazoo.recipe.barrier',
+    'kazoo.recipe.cache',
+    'kazoo.recipe.counter',
+    'kazoo.recipe.election',
+    'kazoo.recipe.lease',
+    'kazoo.recipe.lock',
+    'kazoo.recipe.partitioner',
+    'kazoo.recipe.party',
+    'kazoo.recipe.queue',
+    'kazoo.recipe.watchers',
+    'kazoo.retry',
+    'kazoo.security',
+    'kazoo.testing.common',
+    'kazoo.testing.harness',
+    'kazoo.tests.conftest',
+    'kazoo.tests.test__connection',
+    'kazoo.tests.test_barrier',
+    'kazoo.tests.test_build',
+    'kazoo.tests.test_cache',
+    'kazoo.tests.test_client',
+    'kazoo.tests.test_counter',
+    'kazoo.tests.test_election',
+    'kazoo.tests.test_eventlet_handler',
+    'kazoo.tests.test_exceptions',
+    'kazoo.tests.test_gevent_handler',
+    'kazoo.tests.test_hosts',
+    'kazoo.tests.test_interrupt',
+    'kazoo.tests.test_lease',
+    'kazoo.tests.test_lock',
+    'kazoo.tests.test_partitioner',
+    'kazoo.tests.test_party',
+    'kazoo.tests.test_paths',
+    'kazoo.tests.test_queue',
+    'kazoo.tests.test_retry',
+    'kazoo.tests.test_sasl',
+    'kazoo.tests.test_security',
+    'kazoo.tests.test_selectors_select',
+    'kazoo.tests.test_threading_handler',
+    'kazoo.tests.test_utils',
+    'kazoo.tests.test_watchers',
+    'kazoo.tests.util',
+    'kazoo.version'
+]
+ignore_errors = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,11 +73,14 @@ sasl =
 docs =
     Sphinx>=1.2.2
 
+typing =
+    mypy>=0.991
+
 alldeps =
     %(dev)s
     %(eventlet)s
     %(gevent)s
     %(sasl)s
     %(docs)s
-
+    %(typing)s
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ requires=
     virtualenv>=20.7.2
 skip_missing_interpreters=True
 envlist =
-    pep8,black,
+    pep8,black,mypy,
     gevent,eventlet,sasl,
     docs,
     pypy3
@@ -59,3 +59,11 @@ deps =
 usedevelop = True
 commands = black --check {posargs: {toxinidir}/kazoo {toxinidir}/kazoo}
 
+[testenv:mypy]
+basepython = python3
+extras = alldeps
+deps =
+    mypy
+    mypy: types-mock
+usedevelop = True
+commands = mypy --config-file {toxinidir}/pyproject.toml {toxinidir}/kazoo


### PR DESCRIPTION
## Why is this needed?

This is intended to be a lightweight version of https://github.com/python-zk/kazoo/pull/684. Rather than add types to everything in one shot, support for typing could be added to the build only. Python code typing could be incrementally added in future smaller/targeted PRs.

The changes in https://github.com/python-zk/kazoo/pull/684 are still useful. This is just an effort to split it up to make it easier to understand.

The method used here follows the same pattern that SQLAlchemy has been using to add types. For an example, see https://github.com/sqlalchemy/sqlalchemy/pull/9039/files and note the removal of the `# mypy: ignore-errors` comment to incrementally add types.

## Proposed Changes

  - Add mypy configuration to the build to allow for incremental addition of type annotations.

## Does this PR introduce any breaking change?

No. This PR will only contain build-time type checking.