### PR TITLE
chore(core): pin pytest to 7.1.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ dev =
 test =
     mock
     objgraph
-    pytest
+    pytest<=7.1.3
     pytest-cov
     gevent>=1.2 ; implementation_name!='pypy'
     eventlet>=0.17.1 ; implementation_name!='pypy'


### PR DESCRIPTION
## Why is this needed?

This change is intended to avoid errors like the following at build (tox) time:

```
ModuleNotFoundError: No module named 'py'
```

pytest removed the dependency on py in:

https://github.com/pytest-dev/pytest/commit/19dda7c9bdc8ef71c792e0f77a9595bfad8d9248

This change pins the version of pytest to one that includes py until a path forward can be agreed on (e.g. include py explicitly or via a transitive dependency).

## Proposed Changes

  - Pin pytest from latest (currently 7.2.1) to 7.1.3.

## Does this PR introduce any breaking change?

No. This change affects build/test only.