### PR TITLE
chore: migrate to tox 4.x

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install required dependencies
         run: |
           python3 -m pip install --upgrade pip
-          pip install tox tox-wheel
+          pip install tox
 
       - name: Code check
         run: tox -e ${TOX_VENV}

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
-minversion = 3.24.1
+minversion = 4.3.4
 requires=
     virtualenv>=20.7.2
-    tox-wheel>=0.6.0
 skip_missing_interpreters=True
 envlist =
     pep8,black,
@@ -31,11 +30,13 @@ extras =
 deps =
     sasl: kerberos
     codecov: codecov
+allowlist_externals =
+    {toxinidir}/ensure-zookeeper-env.sh
+    {toxinidir}/init_krb5.sh
 commands =
     sasl: {toxinidir}/init_krb5.sh {envtmpdir}/kerberos \
-        /{toxinidir}/ensure-zookeeper-env.sh \
+        {toxinidir}/ensure-zookeeper-env.sh \
         pytest {posargs: -ra -v --cov-report=xml --cov=kazoo kazoo/tests}
-
 
 [testenv:build]
 


### PR DESCRIPTION
## Why is this needed?

tox-wheel is a deprecated package now that tox 4.x includes wheel support.

## Example error message

When this issue occurs, you may see an error message similar to:

```
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/tox_wheel/plugin.py", line 6, in <module>
    import py
ModuleNotFoundError: No module named 'py'
Error: Process completed with exit code 1.
```

## Proposed Changes

  - remove dependency on tox-wheel
  - use tox 4.x

## Does this PR introduce any breaking change?

No. Build time changes only.