### PR TITLE
Ask Dependabot to bump actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I noticed some of our GitHub action workflows are throwing deprecation warnings...

Let's have Dependbot open PR's to bump them whenever they're outdated.

We could also enable it for watching our Python deps, but that may be more controversial, so that can be done as a follow-on PR if there's interest.