### PR TITLE
chore: add a per test 3min timeout and enable color output

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -5,3 +5,4 @@ flake8==5.0.2
 objgraph==3.5.0
 pytest==6.2.5
 pytest-cov==3.0.0
+pytest-timeout==2.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,13 @@ extend-exclude = '''
 '''
 
 [tool.pytest.ini_options]
-addopts = "-ra -v"
+addopts = "-ra -v --color=yes"
 log_cli = true
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 log_cli_format = "%(asctime)s %(levelname)s %(message)s"
 log_cli_level = "INFO"
+# Per-test timeout in seconds
+timeout = 180
 
 [tool.mypy]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ test =
     objgraph
     pytest
     pytest-cov
+    pytest-timeout
     gevent>=1.2 ; implementation_name!='pypy'
     eventlet>=0.17.1 ; implementation_name!='pypy'
     pyjks


### PR DESCRIPTION
## Why is this needed?

It's difficult to reproduce, but I've seen the github actions test suite take more than 6 hours. Having a timeout set will allow us to get some sort of useful debug information instead of having github actions kill it off before we can analyze anything.

## Proposed Changes

 - Do not allow any one unit test to take more than an hour. If it takes longer than an hour, kill it off and print some basic debug info (e.g. a stack trace of all/most frames).
 - Enable color pytest output to make pytest easier to read in general.

## Does this PR introduce any breaking change?

No -- this is intended to help debug the test suite.