### PR TITLE
No need to specify `mock`

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -2,7 +2,6 @@
 black==22.10.0
 coverage==6.3.2
 flake8==5.0.2
-mock==3.0.5
 objgraph==3.5.0
 pytest==6.2.5
 pytest-cov==3.0.0

--- a/kazoo/tests/test__connection.py
+++ b/kazoo/tests/test__connection.py
@@ -3,11 +3,11 @@ import os
 import threading
 import time
 import uuid
+from unittest.mock import patch
 import struct
 import sys
 
 import pytest
-import mock
 
 from kazoo.exceptions import ConnectionLoss
 from kazoo.protocol.serialization import (
@@ -160,7 +160,7 @@ class TestConnectionHandler(KazooTestCase):
         # continues to retry. This partially reproduces a rare bug seen
         # in production.
 
-        with mock.patch.object(Connect, "deserialize") as mock_deserialize:
+        with patch.object(Connect, "deserialize") as mock_deserialize:
             mock_deserialize.side_effect = bad_deserialize
             try:
                 handler.select = delayed_select

--- a/kazoo/tests/test_cache.py
+++ b/kazoo/tests/test_cache.py
@@ -2,7 +2,7 @@ import gc
 import importlib
 import uuid
 
-from mock import patch, call, Mock
+from unittest.mock import patch, call, Mock
 import pytest
 from objgraph import count as count_refs_by_type
 

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -4,9 +4,8 @@ import threading
 import time
 import uuid
 import unittest
+from unittest.mock import Mock, MagicMock, patch
 
-import mock
-from mock import patch
 import pytest
 
 from kazoo.testing import KazooTestCase
@@ -479,7 +478,7 @@ class TestClient(KazooTestCase):
             "zookeeper.version=1.",
             "zookeeper.ver",
         ]
-        client.command = mock.MagicMock()
+        client.command = MagicMock()
         client.command.side_effect = side_effects
         with pytest.raises(KazooException):
             client.server_version(retries=len(side_effects) - 1)
@@ -490,7 +489,7 @@ class TestClient(KazooTestCase):
         side_effects = []
         for i in range(0, len(actual_version) + 1):
             side_effects.append(actual_version[0:i])
-        client.command = mock.MagicMock()
+        client.command = MagicMock()
         client.command.side_effect = side_effects
         assert client.server_version(retries=len(side_effects) - 1) == (1, 2)
 
@@ -1343,7 +1342,7 @@ class TestSessionCallbacks(unittest.TestCase):
 class TestCallbacks(KazooTestCase):
     def test_async_result_callbacks_are_always_called(self):
         # create a callback object
-        callback_mock = mock.Mock()
+        callback_mock = Mock()
 
         # simulate waiting for a response
         async_result = self.client.handler.async_result()

--- a/kazoo/tests/test_lock.py
+++ b/kazoo/tests/test_lock.py
@@ -1,7 +1,7 @@
 import collections
-import mock
 import threading
 import unittest
+from unittest.mock import MagicMock
 import uuid
 
 import pytest
@@ -803,7 +803,7 @@ class TestSequence(unittest.TestCase):
         goLock = "_c_8eb60557ba51e0da67eefc47467d3f34-lock-0000000031"
         pyLock = "514e5a831836450cb1a56c741e990fd8__lock__0000000032"
         children = ["hello", goLock, "world", pyLock]
-        client = mock.MagicMock()
+        client = MagicMock()
         client.get_children.return_value = children
         lock = Lock(client, "test")
         assert lock._get_predecessor(pyLock) is None
@@ -815,7 +815,7 @@ class TestSequence(unittest.TestCase):
         goLock = "_c_8eb60557ba51e0da67eefc47467d3f34-lock-0000000031"
         pyLock = "514e5a831836450cb1a56c741e990fd8__lock__0000000032"
         children = ["hello", goLock, "world", pyLock]
-        client = mock.MagicMock()
+        client = MagicMock()
         client.get_children.return_value = children
         lock = Lock(client, "test", extra_lock_patterns=["-lock-"])
         assert lock._get_predecessor(pyLock) == goLock

--- a/kazoo/tests/test_partitioner.py
+++ b/kazoo/tests/test_partitioner.py
@@ -1,8 +1,7 @@
 import uuid
 import threading
 import time
-
-import mock
+from unittest.mock import patch
 
 from kazoo.exceptions import LockTimeout
 from kazoo.testing import KazooTestCase
@@ -154,7 +153,7 @@ class KazooPartitionerTests(KazooTestCase):
             lock = locks.setdefault(path, self.client.handler.lock_object())
             return SlowLockMock(self.client, lock)
 
-        with mock.patch.object(self.client, "Lock", side_effect=get_lock):
+        with patch.object(self.client, "Lock", side_effect=get_lock):
             # Create first partitioner. It will start to acquire the set
             # members.
             self.__create_partitioner(identifier="0", size=2)
@@ -192,7 +191,7 @@ class KazooPartitionerTests(KazooTestCase):
 
             return SlowLockMock(self.client, lock, delay_time=delay_time)
 
-        with mock.patch.object(self.client, "Lock", side_effect=get_lock):
+        with patch.object(self.client, "Lock", side_effect=get_lock):
             # Create first partitioner. It will start to acquire the set
             # members.
             self.__create_partitioner(identifier="0", size=2)

--- a/kazoo/tests/test_threading_handler.py
+++ b/kazoo/tests/test_threading_handler.py
@@ -1,7 +1,7 @@
 import threading
 import unittest
+from unittest.mock import Mock
 
-import mock
 import pytest
 
 
@@ -79,7 +79,7 @@ class TestThreadingAsync(unittest.TestCase):
         return SequentialThreadingHandler()
 
     def test_ready(self):
-        mock_handler = mock.Mock()
+        mock_handler = Mock()
         async_result = self._makeOne(mock_handler)
 
         assert async_result.ready() is False
@@ -89,8 +89,8 @@ class TestThreadingAsync(unittest.TestCase):
         assert async_result.exception is None
 
     def test_callback_queued(self):
-        mock_handler = mock.Mock()
-        mock_handler.completion_queue = mock.Mock()
+        mock_handler = Mock()
+        mock_handler.completion_queue = Mock()
         async_result = self._makeOne(mock_handler)
 
         async_result.rawlink(lambda a: a)
@@ -99,8 +99,8 @@ class TestThreadingAsync(unittest.TestCase):
         assert mock_handler.completion_queue.put.called
 
     def test_set_exception(self):
-        mock_handler = mock.Mock()
-        mock_handler.completion_queue = mock.Mock()
+        mock_handler = Mock()
+        mock_handler.completion_queue = Mock()
         async_result = self._makeOne(mock_handler)
         async_result.rawlink(lambda a: a)
         async_result.set_exception(ImportError("Error occured"))
@@ -109,7 +109,7 @@ class TestThreadingAsync(unittest.TestCase):
         assert mock_handler.completion_queue.put.called
 
     def test_get_wait_while_setting(self):
-        mock_handler = mock.Mock()
+        mock_handler = Mock()
         async_result = self._makeOne(mock_handler)
 
         lst = []
@@ -132,7 +132,7 @@ class TestThreadingAsync(unittest.TestCase):
         th.join()
 
     def test_get_with_nowait(self):
-        mock_handler = mock.Mock()
+        mock_handler = Mock()
         async_result = self._makeOne(mock_handler)
         timeout = self._makeHandler().timeout_exception
 
@@ -143,7 +143,7 @@ class TestThreadingAsync(unittest.TestCase):
             async_result.get_nowait()
 
     def test_get_with_exception(self):
-        mock_handler = mock.Mock()
+        mock_handler = Mock()
         async_result = self._makeOne(mock_handler)
 
         lst = []
@@ -170,7 +170,7 @@ class TestThreadingAsync(unittest.TestCase):
         th.join()
 
     def test_wait(self):
-        mock_handler = mock.Mock()
+        mock_handler = Mock()
         async_result = self._makeOne(mock_handler)
 
         lst = []
@@ -202,7 +202,7 @@ class TestThreadingAsync(unittest.TestCase):
         Guards against the reappearance of:
             https://github.com/python-zk/kazoo/issues/485
         """
-        mock_handler = mock.Mock()
+        mock_handler = Mock()
         async_result = self._makeOne(mock_handler)
 
         async_result.set("immediate")
@@ -225,7 +225,7 @@ class TestThreadingAsync(unittest.TestCase):
         th.join()
 
     def test_set_before_wait(self):
-        mock_handler = mock.Mock()
+        mock_handler = Mock()
         async_result = self._makeOne(mock_handler)
 
         lst = []
@@ -244,7 +244,7 @@ class TestThreadingAsync(unittest.TestCase):
         th.join()
 
     def test_set_exc_before_wait(self):
-        mock_handler = mock.Mock()
+        mock_handler = Mock()
         async_result = self._makeOne(mock_handler)
 
         lst = []
@@ -267,7 +267,7 @@ class TestThreadingAsync(unittest.TestCase):
         th.join()
 
     def test_linkage(self):
-        mock_handler = mock.Mock()
+        mock_handler = Mock()
         async_result = self._makeOne(mock_handler)
         cv = threading.Event()
 
@@ -292,7 +292,7 @@ class TestThreadingAsync(unittest.TestCase):
         th.join()
 
     def test_linkage_not_ready(self):
-        mock_handler = mock.Mock()
+        mock_handler = Mock()
         async_result = self._makeOne(mock_handler)
 
         lst = []
@@ -306,7 +306,7 @@ class TestThreadingAsync(unittest.TestCase):
         assert mock_handler.completion_queue.put.called
 
     def test_link_and_unlink(self):
-        mock_handler = mock.Mock()
+        mock_handler = Mock()
         async_result = self._makeOne(mock_handler)
 
         lst = []
@@ -323,7 +323,7 @@ class TestThreadingAsync(unittest.TestCase):
     def test_captured_exception(self):
         from kazoo.handlers.utils import capture_exceptions
 
-        mock_handler = mock.Mock()
+        mock_handler = Mock()
         async_result = self._makeOne(mock_handler)
 
         @capture_exceptions(async_result)
@@ -338,7 +338,7 @@ class TestThreadingAsync(unittest.TestCase):
     def test_no_capture_exceptions(self):
         from kazoo.handlers.utils import capture_exceptions
 
-        mock_handler = mock.Mock()
+        mock_handler = Mock()
         async_result = self._makeOne(mock_handler)
 
         lst = []
@@ -359,7 +359,7 @@ class TestThreadingAsync(unittest.TestCase):
     def test_wraps(self):
         from kazoo.handlers.utils import wrap
 
-        mock_handler = mock.Mock()
+        mock_handler = Mock()
         async_result = self._makeOne(mock_handler)
 
         lst = []
@@ -378,8 +378,8 @@ class TestThreadingAsync(unittest.TestCase):
         assert async_result.get() == "hello"
 
     def test_multiple_callbacks(self):
-        mockback1 = mock.Mock(name="mockback1")
-        mockback2 = mock.Mock(name="mockback2")
+        mockback1 = Mock(name="mockback1")
+        mockback2 = Mock(name="mockback2")
         handler = self._makeHandler()
         handler.start()
 

--- a/kazoo/tests/test_utils.py
+++ b/kazoo/tests/test_utils.py
@@ -1,6 +1,6 @@
 import unittest
+from unittest.mock import patch
 
-from mock import patch
 import pytest
 
 try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,6 @@ dev =
     flake8
 
 test =
-    mock
     objgraph
     pytest
     pytest-cov


### PR DESCRIPTION
It's now part of the Python stdlib since `3.3`.

So no need to specify it.