### PR TITLE
debug: try bumping mock version

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -2,7 +2,7 @@
 black==22.10.0
 coverage==6.3.2
 flake8==5.0.2
-mock==3.0.5
+mock==5.0.1
 objgraph==3.5.0
 pytest==6.2.5
 pytest-cov==3.0.0


### PR DESCRIPTION
Seeing a weird error in https://github.com/python-zk/kazoo/pull/702/ and wondering if it's because latest `mock` is actually `5.0.1`: https://mock.readthedocs.io/en/latest/changelog.html

so threw this up to see what CI thinks