### PR TITLE
Cleanup SSL deprecation warnings under Python 3.10 and newer

### DIFF
--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -225,7 +225,7 @@ def create_tcp_connection(
 
         if use_ssl:
             # Disallow use of SSLv2 and V3 (meaning we require TLSv1.0+)
-            context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
             if options is not None:
                 context.options = options
@@ -238,15 +238,17 @@ def create_tcp_connection(
 
             # Load default CA certs
             context.load_default_certs(ssl.Purpose.SERVER_AUTH)
+            # We must set check_hostname to False prior to setting
+            # verify_mode to CERT_NONE.
+            # TODO: Make hostname verification configurable as some users may
+            # elect to use it.
+            context.check_hostname = False
             context.verify_mode = (
-                ssl.CERT_OPTIONAL if verify_certs else ssl.CERT_NONE
+                ssl.CERT_REQUIRED if verify_certs else ssl.CERT_NONE
             )
             if ca:
                 context.load_verify_locations(ca)
             if certfile and keyfile:
-                context.verify_mode = (
-                    ssl.CERT_REQUIRED if verify_certs else ssl.CERT_NONE
-                )
                 context.load_cert_chain(
                     certfile=certfile,
                     keyfile=keyfile,


### PR DESCRIPTION
Prior to this commit python would produce these warnings when using kazoo with ssl:

```
  /path/to/venv/lib/python3.11/site-packages/kazoo/handlers/utils.py:225: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
```

The reason for this is that `ssl.PROTOCOL_SSLv23` is an alias for `ssl.PROTOCOL_TLS` and `ssl.PROTOCOL_TLS` is deprecated since Python 3.10.

`ssl.PROTOCOL_TLS` was replaced with `ssl.PROTOCOL_TLS_CLIENT` and `ssl.PROTOCOL_TLS_SERVER`. In kazoo's case we switch to `ssl.PROTOCOL_TLS_CLIENT` as kazoo is acting as an ssl client to zookeeper servers.

There are a few things to note. `PROTOCOL_TLS_CLIENT` enables `context.check_hostname`. We explicitly set this to False as this is required to set `ssl.CHECK_NONE` which kazoo supports, and not everyone may be using SSL certs with proper hostnames configured. For example if making connections to an IP address rather than a name and the certs don't have IP addrs in their altnames. This ensures backward compatibility with these use cases. Changing this should be done in a separate change and should likely be made configurable like verify_certs.

Finally, while we are at it we replace `ssl.CERT_OPTIONAL` with `ssl.CERT_REQUIRED` as they are equivalent in a client context. This allows us to delete some code.

Python documents all of these behaviors as being present since Python 3.6. Kazoo requires Python 3.7 or newer which should make this safe.

## Why is this needed?

This change should avoid problems with future Python updates. It also cuts down on noise in things like test suites that use kazoo under python3.10 or newer which is nice for end users.

## Proposed Changes

  - Use `ssl.PROTOCOL_TLS_CLIENT` instead of `ssl.PROTOCOL_SSLv23`
  - Replaced `ssl.CERT_OPTIONAL` with `ssl.CERT_REQUIRED` as they are equivalent in this context. Doing so allows us to delete some code

## Does this PR introduce any breaking change?

I've intentionally tried to make this backward compatible by setting context.check_hostname to False preserving old behavior. I think any changes to this behavior should happen in a separate change that can more fully understand the impacts.
