### PR TITLE
chore(core): Fix documentation build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,32 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+formats: []
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+  - method: pip
+    path: .
+    extra_requirements:
+    - docs

--- a/constraints.txt
+++ b/constraints.txt
@@ -5,9 +5,3 @@ flake8==5.0.2
 objgraph==3.5.0
 pytest==6.2.5
 pytest-cov==3.0.0
-
-# Documentation building.
-Jinja2==2.7.3
-Pygments==1.6
-Sphinx==1.2.2
-docutils==0.12

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.viewcode",
+    "sphinx_autodoc_typehints",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,7 @@ sasl =
 
 docs =
     Sphinx>=1.2.2
+    sphinx-autodoc-typehints>=1
 
 typing =
     mypy>=0.991


### PR DESCRIPTION
Fixes #699 

## Why is this needed?

Configure readthedocs documentation build directly in the project.

## Proposed Changes

  - use `.readthedocs.yaml`
  - Include sphinx-autodoc-typehints

## Does this PR introduce any breaking change?

No
