### PR TITLE
feat: add support for persistent recursive watches

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -25,6 +25,7 @@ from kazoo.loggingsupport import BLATHER
 from kazoo.protocol.connection import ConnectionHandler
 from kazoo.protocol.paths import _prefix_root, normpath
 from kazoo.protocol.serialization import (
+    AddWatch,
     Auth,
     CheckVersion,
     CloseInstance,
@@ -38,6 +39,7 @@ from kazoo.protocol.serialization import (
     SetACL,
     GetData,
     Reconfig,
+    RemoveWatches,
     SetData,
     Sync,
     Transaction,
@@ -248,6 +250,7 @@ class KazooClient(object):
         self.state_listeners = set()
         self._child_watchers = defaultdict(set)
         self._data_watchers = defaultdict(set)
+        self._persistent_watchers = defaultdict(set)
         self._reset()
         self.read_only = read_only
 
@@ -416,8 +419,12 @@ class KazooClient(object):
         for data_watchers in self._data_watchers.values():
             watchers.extend(data_watchers)
 
+        for persistent_watchers in self._persistent_watchers.values():
+            watchers.extend(persistent_watchers)
+
         self._child_watchers = defaultdict(set)
         self._data_watchers = defaultdict(set)
+        self._persistent_watchers = defaultdict(set)
 
         ev = WatchedEvent(EventType.NONE, self._state, None)
         for watch in watchers:
@@ -1644,8 +1651,100 @@ class KazooClient(object):
 
         return async_result
 
+    def add_watch(self, path, watch, mode):
+        """Add a watch.
+
+        This method adds persistent watches.  Unlike the data and
+        child watches which may be set by calls to
+        :meth:`KazooClient.exists`, :meth:`KazooClient.get`, and
+        :meth:`KazooClient.get_children`, persistent watches are not
+        removed after being triggered.
+
+        To remove a persistent watch, use
+        :meth:`KazooClient.remove_all_watches` with an argument of
+        :attr:`~kazoo.states.WatcherType.ANY`.
+
+        The `mode` argument determines whether or not the watch is
+        recursive.  To set a persistent watch, use
+        :class:`~kazoo.states.AddWatchMode.PERSISTENT`.  To set a
+        persistent recursive watch, use
+        :class:`~kazoo.states.AddWatchMode.PERSISTENT_RECURSIVE`.
+
+        :param path: Path of node to watch.
+        :param watch: Watch callback to set for future changes
+                      to this path.
+        :param mode: The mode to use.
+        :type mode: int
+
+        :raises:
+            :exc:`~kazoo.exceptions.MarshallingError` if mode is
+            unknown.
+
+            :exc:`~kazoo.exceptions.ZookeeperError` if the server
+            returns a non-zero error code.
+        """
+        return self.add_watch_async(path, watch, mode).get()
+
+    def add_watch_async(self, path, watch, mode):
+        """Asynchronously add a watch. Takes the same arguments as
+        :meth:`add_watch`.
+        """
+        if not isinstance(path, str):
+            raise TypeError("Invalid type for 'path' (string expected)")
+        if not callable(watch):
+            raise TypeError("Invalid type for 'watch' (must be a callable)")
+        if not isinstance(mode, int):
+            raise TypeError("Invalid type for 'mode' (int expected)")
+
+        async_result = self.handler.async_result()
+        self._call(
+            AddWatch(_prefix_root(self.chroot, path), watch, mode),
+            async_result,
+        )
+        return async_result
+
+    def remove_all_watches(self, path, watcher_type):
+        """Remove watches from a path.
+
+        This removes all watches of a specified type (data, child,
+        any) from a given path.
+
+        The `watcher_type` argument specifies which type to use.  It
+        may be one of:
+
+        * :attr:`~kazoo.states.WatcherType.DATA`
+        * :attr:`~kazoo.states.WatcherType.CHILD`
+        * :attr:`~kazoo.states.WatcherType.ANY`
+
+        To remove persistent watches, specify a watcher type of
+        :attr:`~kazoo.states.WatcherType.ANY`.
+
+        :param path: Path of watch to remove.
+        :param watcher_type: The type of watch to remove.
+        :type watcher_type: int
+        """
+
+        return self.remove_all_watches_async(path, watcher_type).get()
+
+    def remove_all_watches_async(self, path, watcher_type):
+        """Asynchronously remove watches. Takes the same arguments as
+        :meth:`remove_all_watches`.
+        """
+        if not isinstance(path, str):
+            raise TypeError("Invalid type for 'path' (string expected)")
+        if not isinstance(watcher_type, int):
+            raise TypeError("Invalid type for 'watcher_type' (int expected)")
+
+        async_result = self.handler.async_result()
+        self._call(
+            RemoveWatches(_prefix_root(self.chroot, path), watcher_type),
+            async_result,
+        )
+        return async_result
+
 
 class TransactionRequest(object):
+
     """A Zookeeper Transaction Request
 
     A Transaction provides a builder object that can be used to

--- a/kazoo/exceptions.py
+++ b/kazoo/exceptions.py
@@ -187,6 +187,11 @@ class NotReadOnlyCallError(ZookeeperError):
     a read-only server"""
 
 
+@_zookeeper_exception(-121)
+class NoWatcherError(ZookeeperError):
+    """No watcher was found at the supplied path"""
+
+
 class ConnectionClosedError(SessionExpiredError):
     """Connection is closed"""
 

--- a/kazoo/protocol/serialization.py
+++ b/kazoo/protocol/serialization.py
@@ -416,6 +416,20 @@ class Reconfig(
         return data, stat
 
 
+class RemoveWatches(namedtuple("RemoveWatches", "path watcher_type")):
+    type = 18
+
+    def serialize(self):
+        b = bytearray()
+        b.extend(write_string(self.path))
+        b.extend(int_struct.pack(self.watcher_type))
+        return b
+
+    @classmethod
+    def deserialize(cls, bytes, offset):
+        return None
+
+
 class Auth(namedtuple("Auth", "auth_type scheme auth")):
     type = 100
 
@@ -439,6 +453,20 @@ class SASL(namedtuple("SASL", "challenge")):
     def deserialize(cls, bytes, offset):
         challenge, offset = read_buffer(bytes, offset)
         return challenge, offset
+
+
+class AddWatch(namedtuple("AddWatch", "path watcher mode")):
+    type = 106
+
+    def serialize(self):
+        b = bytearray()
+        b.extend(write_string(self.path))
+        b.extend(int_struct.pack(self.mode))
+        return b
+
+    @classmethod
+    def deserialize(cls, bytes, offset):
+        return None
 
 
 class Watch(namedtuple("Watch", "type state path")):

--- a/kazoo/protocol/states.py
+++ b/kazoo/protocol/states.py
@@ -251,3 +251,43 @@ class ZnodeStat(
     @property
     def children_count(self):
         return self.numChildren
+
+
+class AddWatchMode(object):
+    """Modes for use with :meth:`~kazoo.client.KazooClient.add_watch`
+
+    .. attribute:: PERSISTENT
+
+        The watch is not removed when trigged.
+
+    .. attribute:: PERSISTENT_RECURSIVE
+
+        The watch is not removed when trigged, and applies to all
+        paths underneath the supplied path as well.
+    """
+
+    PERSISTENT = 0
+    PERSISTENT_RECURSIVE = 1
+
+
+class WatcherType(object):
+    """Watcher types for use with :meth:`~kazoo.client.KazooClient.remove_all_watches`
+
+    .. attribute:: CHILDREN
+
+        Child watches.
+
+    .. attribute:: DATA
+
+        Data watches.
+
+    .. attribute:: ANY
+
+        Any type of watch (child, data, persistent, or persistent
+        recursive).
+
+    """
+
+    CHILDREN = 1
+    DATA = 2
+    ANY = 3


### PR DESCRIPTION
## Why is this needed?

ZooKeeper 3.6.0 added support for persistent, and persistent recursive watches.  This adds the corresponding support to the Kazoo client class.

## Does this PR introduce any breaking change?

No breaking changes.
