### PR TITLE
fix command just recv 8K

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -769,7 +769,10 @@ class KazooClient(object):
             verify_certs=self.verify_certs,
         )
         sock.sendall(cmd)
-        result = sock.recv(8192)
+        result = b""
+        temp = sock.recv(8192)
+        while temp:
+            result += temp
         sock.close()
         return result.decode("utf-8", "replace")
 


### PR DESCRIPTION
Fixes #

## Why is this needed?
sock.recv(8192)
recv byte 8K, Can not be modified，there will be data loss


