### PR TITLE
fix(testing): add `.coveragerc`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+include =
+    kazoo/*
+omit =
+    kazoo/tests/*
+    kazoo/testing/*


### PR DESCRIPTION
## Why is this needed?
This fixes the `coverage` configuration that is wrongly giving a test coverage for the `tests` and `testing` folders and ends up "blocking" PR because of `codecov`.

## Proposed Changes

  - add `.coveragerc` file and exclude `tests` and `testing` folder all together

## Does this PR introduce any breaking change?
No, only good stuff here.
