### PR TITLE
feat(ci): remove `codecov` step from `tox` since performed in GA

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Test with tox
         run: tox -e ${TOX_VENV}
         env:
-          TOX_VENV: ${{ format('{0}-{1}', matrix.tox-env, 'gevent-eventlet-sasl,codecov') }}
+          TOX_VENV: ${{ format('{0}-{1}', matrix.tox-env, 'gevent-eventlet-sasl') }}
           ZOOKEEPER_VERSION: ${{ matrix.zk-version }}
           # TODO: can be removed once tests for ZK 3.4 are removed
           ZOOKEEPER_PREFIX: "${{ !contains(matrix.zk-version, '3.4') && 'apache-' || '' }}"

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,6 @@ extras =
     sasl: sasl
 deps =
     sasl: kerberos
-    codecov: codecov
 allowlist_externals =
     {toxinidir}/ensure-zookeeper-env.sh
     {toxinidir}/init_krb5.sh
@@ -39,9 +38,6 @@ commands =
         pytest {posargs: -ra -v --cov-report=xml --cov=kazoo kazoo/tests}
 
 [testenv:build]
-
-[testenv:codecov]
-commands = - codecov -e TOX_VENV,ZOOKEEPER_VERSION
 
 [testenv:pep8]
 basepython = python3


### PR DESCRIPTION
## Why is this needed?
There is no need to perform the non-working `codecov` step via `tox` since we now have a Github Actions step that performs it.
## Proposed Changes

  - update `tox.ini` and remove `codecov` related stuff
  - update GA `testing.yml` to remove `codecov` from matrix

## Does this PR introduce any breaking change?
Nah.
