### PR TITLE
fix(exceptions): Register exception for server-side QUOTAEXCEEDED(-125)

### DIFF
--- a/kazoo/exceptions.py
+++ b/kazoo/exceptions.py
@@ -187,6 +187,11 @@ class NotReadOnlyCallError(ZookeeperError):
     a read-only server"""
 
 
+@_zookeeper_exception(-125)
+class QuotaExceededError(ZookeeperError):
+    """Exceeded the quota that was set on the path"""
+
+
 class ConnectionClosedError(SessionExpiredError):
     """Connection is closed"""
 


### PR DESCRIPTION
## Why is this needed?

Without this, out-of-quota conditions cause Kazoo's request handling thread to die, and the application is left waiting for a non-existent reply and/or does not receive any clue that its Kazoo client handle is not functional anymore.

## Proposed Changes

This minimal fix adds the missing definition for `QUOTAEXCEEDED`.

Subsequent PRs could:

  * Synchronize Kazoo exceptions with the full set of known ZooKeeper error codes, and
  * Fall back to a generic exception (rather than silently zombifying) if an unknown error code is encountered.

## Does this PR introduce any breaking change?

It is not expected to.