### PR TITLE
fix(log): add logger for kazoo.handlers.threading

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -221,7 +221,9 @@ class KazooClient(object):
         self.logger = logger or log
 
         # Record the handler strategy used
-        self.handler = handler or SequentialThreadingHandler(logger=self.logger)
+        self.handler = handler
+        if not handler:
+            self.handler = SequentialThreadingHandler(logger=self.logger)
         if inspect.isclass(self.handler):
             raise ConfigurationError(
                 "Handler must be an instance of a class, "

--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -221,7 +221,7 @@ class KazooClient(object):
         self.logger = logger or log
 
         # Record the handler strategy used
-        self.handler = handler if handler else SequentialThreadingHandler()
+        self.handler = handler or SequentialThreadingHandler(logger=self.logger)
         if inspect.isclass(self.handler):
             raise ConfigurationError(
                 "Handler must be an instance of a class, "

--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -110,6 +110,8 @@ class SequentialThreadingHandler(object):
         return self._running
 
     def _create_thread_worker(self, work_queue):
+        log = self.logger
+
         def _thread_worker():  # pragma: nocover
             while True:
                 try:
@@ -119,7 +121,7 @@ class SequentialThreadingHandler(object):
                             break
                         func()
                     except Exception:
-                        self.logger.exception("Exception in worker queue thread")
+                        log.exception("Exception in worker queue thread")
                     finally:
                         work_queue.task_done()
                         del func  # release before possible idle

--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -96,8 +96,9 @@ class SequentialThreadingHandler(object):
     queue_impl = queue.Queue
     queue_empty = queue.Empty
 
-    def __init__(self):
+    def __init__(self, logger=None):
         """Create a :class:`SequentialThreadingHandler` instance"""
+        self.logger = logger or log
         self.callback_queue = self.queue_impl()
         self.completion_queue = self.queue_impl()
         self._running = False
@@ -118,7 +119,7 @@ class SequentialThreadingHandler(object):
                             break
                         func()
                     except Exception:
-                        log.exception("Exception in worker queue thread")
+                        self.logger.exception("Exception in worker queue thread")
                     finally:
                         work_queue.task_done()
                         del func  # release before possible idle


### PR DESCRIPTION
Fixes #724

No handlers could be found for logger "kazoo.handlers.threading"

for better logging control, just like kazoo.client does

