### PR TITLE
fix(recipe): prevent perpetual re-election if sequence node overflows

### DIFF
--- a/kazoo/recipe/lock.py
+++ b/kazoo/recipe/lock.py
@@ -276,7 +276,7 @@ class Lock(object):
         (e.g. rlock), this and also edge cases where the lock's ephemeral node
         is gone.
         """
-        node_sequence = node[len(self.prefix) :]
+        node_sequence = int(node[len(self.prefix) :])
         children = self.client.get_children(self.path)
         found_self = False
         # Filter out the contenders using the computed regex
@@ -284,7 +284,7 @@ class Lock(object):
         for child in children:
             match = self._contenders_re.search(child)
             if match is not None:
-                contender_sequence = match.group(1)
+                contender_sequence = int(match.group(1))
                 # Only consider contenders with a smaller sequence number.
                 # A contender with a smaller sequence number has a higher
                 # priority.

--- a/kazoo/tests/test_lock.py
+++ b/kazoo/tests/test_lock.py
@@ -800,6 +800,46 @@ class TestSemaphore(KazooTestCase):
 class TestSequence(unittest.TestCase):
     def test_get_predecessor(self):
         """Validate selection of predecessors."""
+        pyLock_prefix = "514e5a831836450cb1a56c741e990fd8__lock__"
+        pyLock_predecessor = f"{pyLock_prefix}0000000030"
+        pyLock = f"{pyLock_prefix}0000000031"
+        pyLock_successor = f"{pyLock_prefix}0000000032"
+        children = [
+            "hello",
+            pyLock_predecessor,
+            "world",
+            pyLock,
+            pyLock_successor,
+        ]
+        client = MagicMock()
+        client.get_children.return_value = children
+        lock = Lock(client, "test")
+        assert lock._get_predecessor(pyLock) == pyLock_predecessor
+
+    def test_get_predecessor_with_overflowed_sequence(self):
+        """Validate selection of predecessors with negative sequence.
+
+        This can occur in case of an integer overflow, if the sequence
+        counter is incremented beyond 2147483647.
+        """
+        pyLock_prefix = "514e5a831836450cb1a56c741e990fd8__lock__"
+        pyLock_predecessor = f"{pyLock_prefix}-0000000032"
+        pyLock = f"{pyLock_prefix}-0000000031"
+        pyLock_successor = f"{pyLock_prefix}-0000000030"
+        children = [
+            "hello",
+            pyLock_predecessor,
+            "world",
+            pyLock,
+            pyLock_successor,
+        ]
+        client = MagicMock()
+        client.get_children.return_value = children
+        lock = Lock(client, "test")
+        assert lock._get_predecessor(pyLock) == pyLock_predecessor
+
+    def test_get_predecessor_no_predecessor(self):
+        """Validate selection of predecessors."""
         goLock = "_c_8eb60557ba51e0da67eefc47467d3f34-lock-0000000031"
         pyLock = "514e5a831836450cb1a56c741e990fd8__lock__0000000032"
         children = ["hello", goLock, "world", pyLock]


### PR DESCRIPTION
Once sequence node is incremented beyond 2147483647, the sequence overflows into the negative space. When getting predecessors, cast the node sequence from String to int before comparing.

Closes #730

## Why is this needed?

Prevents perpetual re-election if sequence nodes is incremented beyond 2147483647. Previously the sequence node comparison was comparing two Strings, with this change the comparison is done with integers instead. This means that the only re-election due to an integer overflow will happen when incrementing from 2147483647 to -2147483648, but any subsequent increment will not result in a re-election.

## Proposed Changes

  - use integer comparison instead of string comparison when comparing sequence nodes

## Does this PR introduce any breaking change?

No

