### PR TITLE
test: update Python and ZK in testing suite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
     - name: Handle the code
       uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
 
     - name: Install pypa/build
       run: >-

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Handle pip cache
         uses: actions/cache@v4
@@ -52,17 +52,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.10-v7.3.15"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.10-v7.3.15"]
         zk-version: ["3.4.14", "3.5.10", "3.6.3", "3.7.1"]
         include:
-          - python-version: "3.7"
-            tox-env: py37
           - python-version: "3.8"
             tox-env: py38
           - python-version: "3.9"
             tox-env: py39
           - python-version: "3.10"
             tox-env: py310
+          - python-version: "3.11"
+            tox-env: py311
+          - python-version: "3.12"
+            tox-env: py312
           - python-version: "pypy-3.10-v7.3.15"
             tox-env: pypy3
     steps:
@@ -118,7 +120,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Handle pip cache
         uses: actions/cache@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.10-v7.3.15"]
-        zk-version: ["3.4.14", "3.5.10", "3.6.3", "3.7.1"]
+        zk-version: ["3.6.4", "3.7.2", "3.8.3", "3.9.1"]
         include:
           - python-version: "3.8"
             tox-env: py38
@@ -153,7 +153,7 @@ jobs:
       - name: Test with tox
         run: tox -e py310
         env:
-          ZOOKEEPER_VERSION: 3.7.1
+          ZOOKEEPER_VERSION: 3.9.1
           ZOOKEEPER_PREFIX: "apache-"
           ZOOKEEPER_SUFFIX: "-bin"
           ZOOKEEPER_LIB: "lib"

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,10 +19,11 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Communications


### PR DESCRIPTION
Fixes #708 

## Why is this needed?
[Python 3.7 is EOL since last year, Python 3.11 and Python 3.12 are here now.](https://devguide.python.org/versions/)
[ZK 3.6 is EOL since end of 2022 and ZK 3.9 is here.](https://zookeeper.apache.org/releases.html)

## Proposed Changes
  - drop Python 3.7 from testing
  - add Python 3.11 and 3.12 to testing
  - drop ZK 3.4 and 3.5
  - add ZK 3.8 and 3.9

## Does this PR introduce any breaking change?
No.
