### PR TITLE
fix(core): prefer use of `time.monotonic`

### DIFF
--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -212,11 +212,11 @@ def create_tcp_connection(
         # this ugliness...
         timeout = module.getdefaulttimeout()
     if timeout is not None:
-        end = time.time() + timeout
+        end = time.monotonic() + timeout
     sock = None
 
     while True:
-        timeout_at = end if end is None else end - time.time()
+        timeout_at = end if end is None else end - time.monotonic()
         # The condition is not '< 0' here because socket.settimeout treats 0 as
         # a special case to put the socket in non-blocking mode.
         if timeout_at is not None and timeout_at <= 0:

--- a/kazoo/recipe/watchers.py
+++ b/kazoo/recipe/watchers.py
@@ -449,4 +449,4 @@ class PatientChildrenWatch(object):
 
     def _children_watcher(self, async_result, event):
         self.children_changed.set()
-        async_result.set(time.time())
+        async_result.set(time.monotonic())

--- a/kazoo/retry.py
+++ b/kazoo/retry.py
@@ -128,7 +128,7 @@ class KazooRetry(object):
         while True:
             try:
                 if self.deadline is not None and self._cur_stoptime is None:
-                    self._cur_stoptime = time.time() + self.deadline
+                    self._cur_stoptime = time.monotonic() + self.deadline
                 return func(*args, **kwargs)
             except ConnectionClosedError:
                 raise
@@ -144,7 +144,7 @@ class KazooRetry(object):
 
                 if (
                     self._cur_stoptime is not None
-                    and time.time() + sleeptime >= self._cur_stoptime
+                    and time.monotonic() + sleeptime >= self._cur_stoptime
                 ):
                     raise RetryFailedError("Exceeded retry deadline")
 

--- a/kazoo/tests/util.py
+++ b/kazoo/tests/util.py
@@ -95,7 +95,7 @@ class Wait(object):
         timeout=None,
         wait=None,
         exception=None,
-        getnow=(lambda: time.time),
+        getnow=(lambda: time.monotonic),
         getsleep=(lambda: time.sleep),
     ):
         if timeout is not None:


### PR DESCRIPTION
Fixes #722

## Why is this needed?
`time.time()` is subject to changes in system local time and can trigger unexpected behavior. Prefer the use of `time.monotonic` instead of `time.time` since we are not making use of the actual time, only an amount of time elapsed.

## Proposed Changes
  - replace use of `time.time()` with `time.monotonic()`

## Does this PR introduce any breaking change?
No
