### PR TITLE
fix(core): Add missing Zookeeper exceptions codes

### DIFF
--- a/kazoo/exceptions.py
+++ b/kazoo/exceptions.py
@@ -1,4 +1,5 @@
 """Kazoo Exceptions"""
+
 from collections import defaultdict
 
 
@@ -66,6 +67,10 @@ def _zookeeper_exception(code):
     return decorator
 
 
+# Pulled from zookeeper-server/src/main/java/org/apache/zookeeper/
+# KeeperException.java in the Java Zookeeper server source code.
+
+
 @_zookeeper_exception(0)
 class RolledBackError(ZookeeperError):
     pass
@@ -73,123 +78,183 @@ class RolledBackError(ZookeeperError):
 
 @_zookeeper_exception(-1)
 class SystemZookeeperError(ZookeeperError):
-    pass
+    """System and server-side errors.
+    This is never thrown by the server, it shouldn't be used other than to
+    indicate a range. Specifically error codes greater than this value, but
+    lesser than APIError, are system errors.
+    """
 
 
 @_zookeeper_exception(-2)
 class RuntimeInconsistency(ZookeeperError):
-    pass
+    """A runtime inconsistency was found."""
 
 
 @_zookeeper_exception(-3)
 class DataInconsistency(ZookeeperError):
-    pass
+    """A data inconsistency was found."""
 
 
 @_zookeeper_exception(-4)
 class ConnectionLoss(ZookeeperError):
-    pass
+    """Connection to the server has been lost."""
 
 
 @_zookeeper_exception(-5)
 class MarshallingError(ZookeeperError):
-    pass
+    """Error while marshalling or unmarshalling data."""
 
 
 @_zookeeper_exception(-6)
 class UnimplementedError(ZookeeperError):
-    pass
+    """Operation is unimplemented."""
 
 
 @_zookeeper_exception(-7)
 class OperationTimeoutError(ZookeeperError):
-    pass
+    """Operation timeout."""
 
 
 @_zookeeper_exception(-8)
 class BadArgumentsError(ZookeeperError):
-    pass
+    """Invalid arguments."""
+
+
+@_zookeeper_exception(-12)
+class UnknownSessionError(ZookeeperError):
+    """Unknown session (internal server use only)."""
 
 
 @_zookeeper_exception(-13)
 class NewConfigNoQuorumError(ZookeeperError):
-    pass
+    """No quorum of new config is connected and up-to-date with the leader of
+    last commmitted config - try invoking reconfiguration after new servers are
+    connected and synced.
+    """
 
 
 @_zookeeper_exception(-14)
 class ReconfigInProcessError(ZookeeperError):
-    pass
+    """Another reconfiguration is in progress -- concurrent reconfigs not
+    supported (yet).
+    """
 
 
 @_zookeeper_exception(-100)
 class APIError(ZookeeperError):
-    pass
+    """API errors.
+    This is never thrown by the server, it shouldn't be used other than to
+    indicate a range. Specifically error codes greater than this value are API
+    errors (while values less than this indicate a system error.
+    """
 
 
 @_zookeeper_exception(-101)
 class NoNodeError(ZookeeperError):
-    pass
+    """Node does not exist."""
 
 
 @_zookeeper_exception(-102)
 class NoAuthError(ZookeeperError):
-    pass
+    """Not authenticated."""
 
 
 @_zookeeper_exception(-103)
 class BadVersionError(ZookeeperError):
-    pass
+    """Version conflict. In case of reconfiguration: reconfig requested from
+    config version X but last seen config has a different version Y.
+    """
 
 
 @_zookeeper_exception(-108)
 class NoChildrenForEphemeralsError(ZookeeperError):
-    pass
+    """Ephemeral nodes may not have children."""
 
 
 @_zookeeper_exception(-110)
 class NodeExistsError(ZookeeperError):
-    pass
+    """The node already exists."""
 
 
 @_zookeeper_exception(-111)
 class NotEmptyError(ZookeeperError):
-    pass
+    """The node has children."""
 
 
 @_zookeeper_exception(-112)
 class SessionExpiredError(ZookeeperError):
-    pass
+    """The session has been expired by the server."""
 
 
 @_zookeeper_exception(-113)
 class InvalidCallbackError(ZookeeperError):
-    pass
+    """Invalid callback specified."""
 
 
 @_zookeeper_exception(-114)
 class InvalidACLError(ZookeeperError):
-    pass
+    """Invalid ACL specified"""
 
 
 @_zookeeper_exception(-115)
 class AuthFailedError(ZookeeperError):
-    pass
+    """Client authentication failed."""
 
 
 @_zookeeper_exception(-118)
 class SessionMovedError(ZookeeperError):
-    pass
+    """Session moved to another server, so operation is ignored."""
 
 
 @_zookeeper_exception(-119)
 class NotReadOnlyCallError(ZookeeperError):
-    """An API call that is not read-only was used while connected to
-    a read-only server"""
+    """An API call that is not read-only was used while connected to a
+    read-only server.
+    """
+
+
+@_zookeeper_exception(-120)
+class EphemeralOnLocalSessionError(ZookeeperError):
+    """Attempt to create ephemeral node on a local session."""
+
+
+@_zookeeper_exception(-121)
+class NoWatcherError(ZookeeperError):
+    """Attempts to remove a non-existing watcher."""
+
+
+@_zookeeper_exception(-122)
+class RequestTimeoutError(ZookeeperError):
+    """Request not completed within max allowed time."""
+
+
+@_zookeeper_exception(-123)
+class ReconfigDisabledError(ZookeeperError):
+    """Attempts to perform a reconfiguration operation when reconfiguration
+    feature is disabled.
+    """
+
+
+@_zookeeper_exception(-124)
+class SessionClosedRequireSaslError(ZookeeperError):
+    """The session has been closed by server because server requires client to
+    do authentication with configured authentication scheme at the server, but
+    client is not configured with required authentication scheme or configured
+    but authentication failed (i.e. wrong credential used.).
+    """
 
 
 @_zookeeper_exception(-125)
 class QuotaExceededError(ZookeeperError):
-    """Exceeded the quota that was set on the path"""
+    """Exceeded the quota that was set on the path."""
+
+
+@_zookeeper_exception(-127)
+class ThrottledOpError(ZookeeperError):
+    """Operation was throttled and not executed at all. This error code
+    indicates that zookeeper server is under heavy load and can't process
+    incoming requests at full speed; please retry with back off.
+    """
 
 
 class ConnectionClosedError(SessionExpiredError):


### PR DESCRIPTION
Sync'd up to Zookeeper 3.9.2 error codes.

## Why is this needed?

Server errors with missing error codes are handled poorly and result in connection close.

## Proposed Changes

  - Add definition for all know error codes as of Zookeeper 3.9.2

## Does this PR introduce any breaking change?

No.