### PR TITLE
Revert "Fix possible endless wait in stop() after AUTH_FAILED error (…

### DIFF
--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -619,7 +619,7 @@ class ConnectionHandler(object):
             self.ping_outstanding.clear()
             last_send = time.monotonic()
             with self._socket_error_handling():
-                while not self.client._stopped.is_set():
+                while True:
                     # Watch for something to read or send
                     jitter_time = random.randint(1, 40) / 100.0
                     deadline = last_send + read_timeout / 2.0 - jitter_time

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -258,8 +258,6 @@ class TestAuthentication(KazooTestCase):
         with pytest.raises(AuthFailedError):
             client.add_auth("unknown-scheme", digest_auth)
 
-        client.stop()
-
     def test_add_auth_on_reconnect(self):
         client = self._get_client()
         client.start()


### PR DESCRIPTION
Revert "Fix possible endless wait in stop() after AUTH_FAILED error (#688)"
    
This reverts commit 5225b3e2fab6fec3b12b789e3cc6f3218429d32d.

The commit being reverted here caused kazoo not to empty the send
queue before disconnecting.  This means that if a client submitted
asynchronous requests and then called client.stop(), the connection
would be closed immediately, usually after only one (but possibly
more) of the submitted requests were sent.  Prior to this, Kazoo
would empty the queue of submitted requests all the way up to and
including the Close request when client.stop() was called.

Another area where this caused problems is in a busy multi-threaded
system.  One thread might decide to gracefully close the connection,
but if there is any traffic generated by another thread, then the
connection would end up terminating without ever sending the Close
request.

Failure to gracefully shutdown a ZooKeeper connection can mean that
other system components need to wait for ephemeral node timeouts to
detect that a component has shutdown.

Given that this behavior is easily reproducible and can have serious
consequences in production, 5225b3e2 is reverted.