### PR TITLE
fix(testing): follow http redirect and use https mirror

### DIFF
--- a/ensure-zookeeper-env.sh
+++ b/ensure-zookeeper-env.sh
@@ -8,7 +8,7 @@ ZOOKEEPER_VERSION=${ZOOKEEPER_VERSION:-3.4.14}
 ZOOKEEPER_PATH="$ZOO_BASE_DIR/$ZOOKEEPER_VERSION"
 ZOOKEEPER_PREFIX=${ZOOKEEPER_PREFIX}
 ZOOKEEPER_SUFFIX=${ZOOKEEPER_SUFFIX}
-ZOO_MIRROR_URL="http://archive.apache.org/dist"
+ZOO_MIRROR_URL="https://archive.apache.org/dist"
 
 
 function download_zookeeper(){
@@ -16,7 +16,7 @@ function download_zookeeper(){
     cd $ZOO_BASE_DIR
     ZOOKEEPER_DOWNLOAD_URL=${ZOO_MIRROR_URL}/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/${ZOOKEEPER_PREFIX}zookeeper-${ZOOKEEPER_VERSION}${ZOOKEEPER_SUFFIX}.tar.gz
     echo "Will download ZK from ${ZOOKEEPER_DOWNLOAD_URL}"
-    (curl --silent -C - $ZOOKEEPER_DOWNLOAD_URL | tar -zx) || echo "Failed downloading ZK from ${ZOOKEEPER_DOWNLOAD_URL}"
+    (curl --silent -L -C - $ZOOKEEPER_DOWNLOAD_URL | tar -zx) || (echo "Failed downloading ZK from ${ZOOKEEPER_DOWNLOAD_URL}" && exit 1)
     mv ${ZOOKEEPER_PREFIX}zookeeper-${ZOOKEEPER_VERSION}${ZOOKEEPER_SUFFIX} $ZOOKEEPER_VERSION
     chmod a+x $ZOOKEEPER_PATH/bin/zkServer.sh
 }

--- a/ensure-zookeeper-env.sh
+++ b/ensure-zookeeper-env.sh
@@ -14,7 +14,9 @@ ZOO_MIRROR_URL="http://archive.apache.org/dist"
 function download_zookeeper(){
     mkdir -p $ZOO_BASE_DIR
     cd $ZOO_BASE_DIR
-    curl --silent -C - $ZOO_MIRROR_URL/zookeeper/zookeeper-$ZOOKEEPER_VERSION/${ZOOKEEPER_PREFIX}zookeeper-${ZOOKEEPER_VERSION}${ZOOKEEPER_SUFFIX}.tar.gz | tar -zx
+    ZOOKEEPER_DOWNLOAD_URL=${ZOO_MIRROR_URL}/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/${ZOOKEEPER_PREFIX}zookeeper-${ZOOKEEPER_VERSION}${ZOOKEEPER_SUFFIX}.tar.gz
+    echo "Will download ZK from ${ZOOKEEPER_DOWNLOAD_URL}"
+    (curl --silent -C - $ZOOKEEPER_DOWNLOAD_URL | tar -zx) || echo "Failed downloading ZK from ${ZOOKEEPER_DOWNLOAD_URL}"
     mv ${ZOOKEEPER_PREFIX}zookeeper-${ZOOKEEPER_VERSION}${ZOOKEEPER_SUFFIX} $ZOOKEEPER_VERSION
     chmod a+x $ZOOKEEPER_PATH/bin/zkServer.sh
 }


### PR DESCRIPTION
So that we can perform testing again and better understand when this step fails.

## Why is this needed?
So that ZK can be downloaded again during testing suite.

## Proposed Changes

  - display a little more information when the step fails
  - follow http redirect
  - use https mirror

## Does this PR introduce any breaking change?
No
