### PR TITLE
fix(core): Proper retry count in KazooRetry

### DIFF
--- a/kazoo/retry.py
+++ b/kazoo/retry.py
@@ -133,10 +133,10 @@ class KazooRetry(object):
             except ConnectionClosedError:
                 raise
             except self.retry_exceptions:
+                self._attempts += 1
                 # Note: max_tries == -1 means infinite tries.
                 if self._attempts == self.max_tries:
                     raise RetryFailedError("Too many retry attempts")
-                self._attempts += 1
                 jitter = random.uniform(
                     1.0 - self.max_jitter, 1.0 + self.max_jitter
                 )


### PR DESCRIPTION
Make sure the number of attempts matches the `max_retry` parameter. Add unit tests to that effect.

## Why is this needed?

So that users can precisely control the number of retries

## Proposed Changes

  - Move the location of the attempt increase to before the check against `max_try` so we don't end up calling `max_tries + 1` times the function.

## Does this PR introduce any breaking change?

No, it shouldn't.