### PR TITLE
Chore update pypy3 to pypy-3.11-v7.3.21

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.10-v7.3.15"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.11-v7.3.21"]
         zk-version: ["3.6.4", "3.7.2", "3.8.3", "3.9.1"]
         include:
           - python-version: "3.8"
@@ -69,7 +69,7 @@ jobs:
             tox-env: py313
           - python-version: "3.14"
             tox-env: py314
-          - python-version: "pypy-3.10-v7.3.15"
+          - python-version: "pypy-3.11-v7.3.21"
             tox-env: pypy3
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #778 

## Why is this needed?

Because all the pypy3 tests fail to validate in CI

## Proposed Changes

  - Update version of pypy3 to 3.11

## Does this PR introduce any breaking change?

I don't know if updating to pyp3.11 counts as breaking, but on the other hand the maintainers of maturin seem disinclined to fix the issue (see https://github.com/PyO3/maturin/issues/3160)