### PR TITLE
chore(testing): Pin openssl version to latest version providing crypto module

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -10,3 +10,4 @@ pytest-cov==3.0.0; python_version=="3.8"
 pytest-cov==7.0.0; python_version > "3.8"
 pytest-timeout==2.2.0; python_version=="3.8"
 pytest-timeout==2.4.0; python_version > "3.8"
+pyOpenSSL<26.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ test =
     gevent>=1.2 ; implementation_name!='pypy'
     eventlet>=0.17.1 ; implementation_name!='pypy'
     pyjks
-    pyopenssl
+    pyOpenSSL
 
 eventlet =
     eventlet>=0.17.1
@@ -81,6 +81,7 @@ docs =
 
 typing =
     mypy>=0.991
+    pyOpenSSL
 
 alldeps =
     %(dev)s
@@ -89,4 +90,3 @@ alldeps =
     %(sasl)s
     %(docs)s
     %(typing)s
-


### PR DESCRIPTION
## Why is this needed?

The latest version of openssl has dropped the crypto module and so nothing builds

## Proposed Changes

Adding a pin of pyOpenSSL to the previous to latest version

## Does this PR introduce any breaking change?

No