### PR TITLE
fix(ci): run apt-get update before installing deps to avoid 404

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -102,6 +102,7 @@ jobs:
 
       - name: Install required dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y install libevent-dev krb5-kdc krb5-admin-server libkrb5-dev
           python3 -m pip install --upgrade pip
           pip install tox


### PR DESCRIPTION
Fixes #

## Why is this needed?

Fix apt related errors (can't find packages, 404) during CI builds

## Proposed Changes

  - The apt index in the base Ubuntu images are stale, just needs an "apt update"


## Does this PR introduce any breaking change?

No, this is a 1 liner